### PR TITLE
fix(rock-calc): composition weighting — snake_case fields + nullish coalesce

### DIFF
--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -2,8 +2,8 @@ import React, { useState, useMemo, useRef, useEffect } from 'react'
 import { Check, X as XIcon, ChevronDown, Zap, Shield, Activity } from 'lucide-react'
 import {
   SHIP_PRESETS, MOD_KEYS, MOD_LABELS, MOD_POSITIVE_IS_GOOD,
-  computeEffectiveModifiers, canBreakRock, computeChargeWindow, formatModPct,
-  cleanElementName, friendlyElementName,
+  computeEffectiveModifiers, canBreakRock, computeChargeWindow, computeRockStats,
+  formatModPct, cleanElementName, friendlyElementName,
 } from './miningUtils'
 
 // Custom styled select replacing native <select>
@@ -206,25 +206,7 @@ export default function RockCalculator({ data }) {
     })
   }, [compElements, elements])
 
-  const rockStats = useMemo(() => {
-    if (elementStats.length === 0) return { resistance: 0, instability: 0.5, optimal_window_midpoint: 0.5, optimal_window_thinness: 0.5 }
-    let totalWeight = 0, avgRes = 0, avgInst = 0, avgMid = 0, avgThin = 0
-    for (const el of elementStats) {
-      const weight = el.maxPct || el.minPct || 1
-      avgRes += (el.stats?.resistance || 0) * weight
-      avgInst += (el.stats?.instability || 0.5) * weight
-      avgMid += (el.stats?.optimal_window_midpoint || 0.5) * weight
-      avgThin += (el.stats?.optimal_window_thinness || 0.5) * weight
-      totalWeight += weight
-    }
-    if (totalWeight === 0) return { resistance: 0, instability: 0.5, optimal_window_midpoint: 0.5, optimal_window_thinness: 0.5 }
-    return {
-      resistance: avgRes / totalWeight,
-      instability: avgInst / totalWeight,
-      optimal_window_midpoint: avgMid / totalWeight,
-      optimal_window_thinness: avgThin / totalWeight,
-    }
-  }, [elementStats])
+  const rockStats = useMemo(() => computeRockStats(elementStats), [elementStats])
 
   const result = useMemo(() => {
     let totalDps = 0
@@ -470,7 +452,7 @@ export default function RockCalculator({ data }) {
                           {friendlyElementName(el.element)}
                         </span>
                         <div className="flex items-center gap-3 text-gray-500 font-mono">
-                          {el.maxPct != null && <span>{el.minPct.toFixed(1)}–{el.maxPct.toFixed(1)}%</span>}
+                          {el.max_pct != null && <span>{el.min_pct.toFixed(1)}–{el.max_pct.toFixed(1)}%</span>}
                           {el.stats?.resistance != null && <span className="text-amber-400/60">R:{el.stats.resistance.toFixed(2)}</span>}
                           {el.stats?.instability != null && <span className="text-red-400/60">I:{el.stats.instability.toFixed(0)}</span>}
                         </div>

--- a/frontend/src/pages/Mining/miningUtils.js
+++ b/frontend/src/pages/Mining/miningUtils.js
@@ -278,6 +278,42 @@ export function formatModPct(value) {
   return value > 0 ? `+${pct}%` : `${pct}%`
 }
 
+// Compute weighted-average rock stats from a list of composition elements.
+// Each element row comes from rock_compositions.composition_json verbatim —
+// snake_case fields { element, min_pct, max_pct, probability, quality_scale }.
+// `elementStats` is the same row with a `stats` property holding the matched
+// mineable_elements row { resistance, instability, optimal_window_midpoint,
+// optimal_window_thinness }.
+//
+// Weighting prefers max_pct (upper composition bound) → min_pct → falls back
+// to 1 if both are missing. Empty input returns neutral defaults. Returns a
+// plain object of { resistance, instability, optimal_window_midpoint,
+// optimal_window_thinness } — all numbers between 0 and 1 (instability/window
+// fields), or a positive resistance value.
+export function computeRockStats(elementStats) {
+  const NEUTRAL = { resistance: 0, instability: 0.5, optimal_window_midpoint: 0.5, optimal_window_thinness: 0.5 }
+  if (!elementStats || elementStats.length === 0) return NEUTRAL
+  let totalWeight = 0, avgRes = 0, avgInst = 0, avgMid = 0, avgThin = 0
+  for (const el of elementStats) {
+    // `||` would corrupt a legitimately zero stat (e.g. instability=0 for a
+    // perfectly stable element) by falling through to the neutral default.
+    // `??` only falls through on null/undefined — preserves true zeros.
+    const weight = el.max_pct || el.min_pct || 1
+    avgRes += (el.stats?.resistance ?? 0) * weight
+    avgInst += (el.stats?.instability ?? 0.5) * weight
+    avgMid += (el.stats?.optimal_window_midpoint ?? 0.5) * weight
+    avgThin += (el.stats?.optimal_window_thinness ?? 0.5) * weight
+    totalWeight += weight
+  }
+  if (totalWeight === 0) return NEUTRAL
+  return {
+    resistance: avgRes / totalWeight,
+    instability: avgInst / totalWeight,
+    optimal_window_midpoint: avgMid / totalWeight,
+    optimal_window_thinness: avgThin / totalWeight,
+  }
+}
+
 // Get the strongest non-zero modifier on a piece of equipment
 export function getStrongestMod(item) {
   let best = null

--- a/frontend/src/pages/Mining/miningUtils.test.js
+++ b/frontend/src/pages/Mining/miningUtils.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { computeRockStats } from './miningUtils'
+
+// Helper: stub a composition element row matching the API shape (snake_case
+// straight from rock_compositions.composition_json) plus the `stats` join
+// that RockCalculator computes by matching against mineable_elements.
+function el({ element, min_pct, max_pct, resistance, instability, mid = 0.5, thin = 0.5 }) {
+  return {
+    element,
+    min_pct,
+    max_pct,
+    probability: 1.0,
+    quality_scale: 1.0,
+    stats: {
+      resistance,
+      instability,
+      optimal_window_midpoint: mid,
+      optimal_window_thinness: thin,
+    },
+  }
+}
+
+describe('computeRockStats', () => {
+  it('returns neutral defaults for empty input', () => {
+    expect(computeRockStats([])).toEqual({
+      resistance: 0,
+      instability: 0.5,
+      optimal_window_midpoint: 0.5,
+      optimal_window_thinness: 0.5,
+    })
+    expect(computeRockStats(null)).toMatchObject({ resistance: 0, instability: 0.5 })
+    expect(computeRockStats(undefined)).toMatchObject({ resistance: 0, instability: 0.5 })
+  })
+
+  it('weights elements by max_pct (snake_case) — regression test for the bug', () => {
+    // Two elements, one with high abundance + low resistance, one with low
+    // abundance + high resistance. If weighting is broken (the bug — both
+    // get weight 1), the average resistance is (10 + 90) / 2 = 50.
+    // With correct max_pct weighting (70 vs 10), the answer is:
+    //   (10 * 70 + 90 * 10) / (70 + 10) = (700 + 900) / 80 = 20
+    const rocks = [
+      el({ element: 'aluminium_ore',  min_pct: 30, max_pct: 70, resistance: 10, instability: 0.2 }),
+      el({ element: 'quantainium_raw', min_pct: 5,  max_pct: 10, resistance: 90, instability: 0.9 }),
+    ]
+    const stats = computeRockStats(rocks)
+    expect(stats.resistance).toBeCloseTo(20, 5)
+    // Sanity — not equal to the broken-equal-weight answer of 50.
+    expect(stats.resistance).not.toBeCloseTo(50, 1)
+  })
+
+  it('weighted-average instability uses max_pct correctly', () => {
+    const rocks = [
+      el({ element: 'a', max_pct: 60, resistance: 0, instability: 0.0 }),
+      el({ element: 'b', max_pct: 40, resistance: 0, instability: 1.0 }),
+    ]
+    const stats = computeRockStats(rocks)
+    // (0.0 * 60 + 1.0 * 40) / 100 = 0.40
+    expect(stats.instability).toBeCloseTo(0.4, 5)
+  })
+
+  it('falls back to min_pct when max_pct is missing, then to 1', () => {
+    // Element 1: only min_pct → weight 50
+    // Element 2: neither set → weight 1
+    const rocks = [
+      { element: 'a', min_pct: 50, stats: { resistance: 10, instability: 0.5, optimal_window_midpoint: 0.5, optimal_window_thinness: 0.5 } },
+      { element: 'b', stats: { resistance: 90, instability: 0.5, optimal_window_midpoint: 0.5, optimal_window_thinness: 0.5 } },
+    ]
+    const stats = computeRockStats(rocks)
+    // (10 * 50 + 90 * 1) / 51 = 590 / 51 ≈ 11.57
+    expect(stats.resistance).toBeCloseTo(590 / 51, 5)
+  })
+
+  it('treats missing stats as the neutral resistance/instability defaults', () => {
+    const rocks = [
+      el({ element: 'a', max_pct: 50, resistance: 100, instability: 0.0 }),
+      { element: 'b', max_pct: 50 }, // no stats join (orphan composition element)
+    ]
+    const stats = computeRockStats(rocks)
+    // Element b contributes resistance=0, instability=0.5 (defaults)
+    // (100*50 + 0*50) / 100 = 50
+    // (0.0*50 + 0.5*50) / 100 = 0.25
+    expect(stats.resistance).toBeCloseTo(50, 5)
+    expect(stats.instability).toBeCloseTo(0.25, 5)
+  })
+
+  it('window midpoint and thinness propagate through the weighted average', () => {
+    const rocks = [
+      el({ element: 'a', max_pct: 50, resistance: 0, instability: 0.5, mid: 0.2, thin: 0.3 }),
+      el({ element: 'b', max_pct: 50, resistance: 0, instability: 0.5, mid: 0.8, thin: 0.7 }),
+    ]
+    const stats = computeRockStats(rocks)
+    expect(stats.optimal_window_midpoint).toBeCloseTo(0.5, 5)
+    expect(stats.optimal_window_thinness).toBeCloseTo(0.5, 5)
+  })
+})


### PR DESCRIPTION
## Why

Gavin reported the Rock Calculator's composition section was broken. Audit found two bugs in the same code path, both present since `RockCalculator.jsx` was authored (commit `a0ee00ae`).

**Bug 1 — camelCase typo against snake_case payload.**

The `/api/gamedata/mining` endpoint returns `rock_compositions.composition_json` verbatim. The stored JSON is snake_case (`min_pct`, `max_pct`, `probability`, `quality_scale`). The component read camelCase (`maxPct`, `minPct`) in two places:

- `rockStats` (line 213) — `const weight = el.maxPct || el.minPct || 1`. Both undefined → weight always `1` → every element weighted identically. The downstream `effectiveResistance`, `chargeWindow`, and "can break rock?" calculations were running against an unweighted simple average rather than the composition-weighted average the game uses.
- Rock-elements display row (line 473) — `el.maxPct != null && <span>{el.minPct...}</span>`. Never rendered. The "X.X–Y.Y%" range chip was invisible.

**Bug 2 — `||` swallows legitimate zeros.**

Same function used `||` as the fallback operator on stat lookups:

```js
avgRes += (el.stats?.resistance || 0) * weight
avgInst += (el.stats?.instability || 0.5) * weight
```

For `instability` / `optimal_window_midpoint` / `optimal_window_thinness`, a legitimately-zero element stat (e.g. a perfectly stable element with `instability = 0`) is falsy → the `||` substitutes the neutral default 0.5. Switched to `??` so only `null`/`undefined` triggers the fallback.

## What

- `frontend/src/pages/Mining/miningUtils.js` — new `computeRockStats(elementStats)` pure function with both bugs fixed.
- `frontend/src/pages/Mining/RockCalculator.jsx` — line 213's inline `useMemo` replaced with a call to the new helper; line 473's camelCase → snake_case so the % range chip renders.
- `frontend/src/pages/Mining/miningUtils.test.js` — new file, 6 tests:
  - empty/null/undefined input → neutral defaults
  - `max_pct` weighting (regression test for bug 1 with assertions that the result is NOT the broken equal-weight value)
  - `max_pct`-then-`min_pct`-then-`1` fallback chain
  - missing-stats join (orphan composition element)
  - zero-instability preservation (regression test for bug 2)
  - window midpoint/thinness propagation

## Test plan

- [x] `cd frontend && npx vitest run src/pages/Mining/miningUtils.test.js` — 6/6
- [x] `cd frontend && npx vitest run` — 285/285 (was 279, +6)
- [x] `npm run typecheck` — clean

## Out of scope (intentionally)

- No backend changes — the API payload is correct as-is, only the consumer was wrong.
- No additional staleness/quality fields surfaced — same scope-discipline as the recent UEX work.
- No coverage of `canBreakRock` or `computeChargeWindow` — those use `rockStats` as input but their own logic wasn't broken.