### PR TITLE
feat(rock-calc): quality band (lean/avg/rich) on resistance + instability

### DIFF
--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -5,7 +5,7 @@ import {
   computeEffectiveModifiers, formatModPct,
   friendlyElementName,
 } from './miningUtils'
-import { computeEffectiveRockStats } from './computeEffectiveRockStats'
+import { computeQualityBand } from './computeEffectiveRockStats'
 import { resolveRockEntity, buildMedianBaseByCategory } from './resolveRockEntity'
 import DepositPicker from './DepositPicker'
 
@@ -193,11 +193,18 @@ function PowerBar({ totalDps, effectiveResistance, canBreak }) {
   )
 }
 
-/** Format a range as "min – max (avg)" or just "value" for single variants. */
-function fmtRange(rangeObj, fmt = (v) => v.toFixed(2)) {
-  if (!rangeObj) return '—'
-  if (rangeObj.min === rangeObj.max) return fmt(rangeObj.min)
-  return `${fmt(rangeObj.min)} – ${fmt(rangeObj.max)} (avg ${fmt(rangeObj.avg)})`
+/** The avg (expected) value of a quality band, formatted. */
+function fmtBandAvg(band, fmt = (v) => v.toFixed(2)) {
+  if (!band || band.avg == null) return '—'
+  return fmt(band.avg)
+}
+
+/** "Lean X → Rich Y" sub-line for a quality band. Collapses to a single
+ *  value when lean and rich coincide (e.g. a single fixed-% element). */
+function fmtBandSpread(band, fmt = (v) => v.toFixed(2)) {
+  if (!band || band.lean == null || band.rich == null) return null
+  if (Math.abs(band.lean - band.rich) < 1e-6) return null
+  return `Lean ${fmt(band.lean)} → Rich ${fmt(band.rich)}`
 }
 
 // Module-scope pure helpers — no implicit closure over component state
@@ -269,6 +276,18 @@ export default function RockCalculator({ data }) {
     return { totalDps, mods: allMods }
   }, [ship, laserIds, moduleIds, gadget])
 
+  // Per-stat quality band. For each target composition we sample the quality
+  // roll (lean/avg/rich); across variants (generic deposit mode) we average
+  // each quality point. `band[key] = { lean, avg, rich }`. The `avg` point is
+  // the expected rock and drives the can-break / charge math; lean→rich shows
+  // how difficulty (esp. instability) climbs with quality.
+  const BAND_KEYS = [
+    'effective_resistance',
+    'effective_resistance_after_laser',
+    'effective_instability_delta',
+    'effective_window_midpoint_delta',
+    'effective_window_thinness_delta',
+  ]
   const aggregatedStats = useMemo(() => {
     if (!pick.depositName) return null
 
@@ -279,49 +298,38 @@ export default function RockCalculator({ data }) {
     const perVariant = targets
       .map((uuid) => {
         const entity = resolveRockEntity(uuid, compositions, data?.rock_entities, medianBaseByCategory)
-        const stats = computeEffectiveRockStats({
+        const qb = computeQualityBand({
           rockEntity: entity,
           elements: buildElements(uuid, compositions, elements),
           globalParams: shipScopeParams,
           laserMods: result.mods,
         })
-        if (!stats) return null
-        return { ...stats, is_fallback: !!entity?.is_fallback }
+        if (!qb) return null
+        return { ...qb, is_fallback: !!entity?.is_fallback }
       })
       .filter(Boolean)
 
     if (perVariant.length === 0) return null
     const anyFallback = perVariant.some((v) => v.is_fallback)
-    if (perVariant.length === 1) return { single: perVariant[0], count: 1, is_fallback: anyFallback }
 
-    const keys = [
-      'effective_resistance',
-      'effective_resistance_after_laser',
-      'effective_instability_delta',
-      'effective_window_midpoint_delta',
-      'effective_window_thinness_delta',
-    ]
-    const agg = { range: {}, single: null, count: perVariant.length, is_fallback: anyFallback }
-    for (const k of keys) {
-      const vals = perVariant.map((s) => s[k]).filter((v) => v != null)
-      if (vals.length === 0) continue
-      agg.range[k] = {
-        min: Math.min(...vals),
-        max: Math.max(...vals),
-        avg: vals.reduce((a, b) => a + b, 0) / vals.length,
+    // band[key] = { lean, avg, rich } averaged across variants at each quality point
+    const mean = (arr) => arr.reduce((a, b) => a + b, 0) / arr.length
+    const band = {}
+    for (const k of BAND_KEYS) {
+      band[k] = {
+        lean: mean(perVariant.map((v) => v.lean?.[k] ?? v.avg[k])),
+        avg: mean(perVariant.map((v) => v.avg[k])),
+        rich: mean(perVariant.map((v) => v.rich?.[k] ?? v.avg[k])),
       }
     }
-    return agg
+    return { band, count: perVariant.length, is_fallback: anyFallback }
   }, [pick, pickerCompositions, compositions, elements, data?.rock_entities, shipScopeParams, medianBaseByCategory, result.mods])
 
-  // Derive display values from aggregatedStats (single or range avg)
+  // Derive display values from the band's avg (expected) quality point.
   const displayStats = useMemo(() => {
     if (!aggregatedStats) return null
 
-    const get = (key) => {
-      if (aggregatedStats.single) return aggregatedStats.single[key]
-      return aggregatedStats.range?.[key]?.avg ?? null
-    }
+    const get = (key) => aggregatedStats.band?.[key]?.avg ?? null
 
     const effectiveResistance = get('effective_resistance') ?? 0
     const effectiveResistanceAfterLaser = get('effective_resistance_after_laser') ?? effectiveResistance
@@ -561,15 +569,10 @@ export default function RockCalculator({ data }) {
                 />
                 <StatCard
                   label="Adjusted Resistance"
-                  value={
-                    aggregatedStats?.single
-                      ? displayStats.effectiveResistanceAfterLaser.toFixed(2)
-                      : fmtRange(aggregatedStats?.range?.effective_resistance_after_laser)
-                  }
+                  value={fmtBandAvg(aggregatedStats?.band?.effective_resistance_after_laser)}
                   subtitle={
-                    aggregatedStats?.single
-                      ? `Base ${displayStats.effectiveResistance.toFixed(2)} × ${(1 - (result.mods.mod_resistance || 0)).toFixed(3)}`
-                      : `${aggregatedStats?.count} variants`
+                    fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser)
+                    ?? (aggregatedStats?.count > 1 ? `${aggregatedStats.count} variants` : 'expected roll')
                   }
                   color="text-amber-400"
                 />
@@ -580,15 +583,12 @@ export default function RockCalculator({ data }) {
                   glow
                 />
                 <StatCard
-                  label="Instability Delta"
-                  value={
-                    aggregatedStats?.single
-                      ? (displayStats.instabilityDelta >= 0
-                          ? `+${displayStats.instabilityDelta.toFixed(3)}`
-                          : displayStats.instabilityDelta.toFixed(3))
-                      : fmtRange(aggregatedStats?.range?.effective_instability_delta, (v) => v.toFixed(3))
+                  label="Instability"
+                  value={fmtBandAvg(aggregatedStats?.band?.effective_instability_delta, (v) => (v >= 0 ? `+${v.toFixed(3)}` : v.toFixed(3)))}
+                  subtitle={
+                    fmtBandSpread(aggregatedStats?.band?.effective_instability_delta, (v) => v.toFixed(3))
+                    ?? 'rises with quality'
                   }
-                  subtitle="Element modifier sum"
                   color={displayStats.instabilityDelta > 0.2 ? 'text-red-400' : displayStats.instabilityDelta > 0.05 ? 'text-amber-400' : 'text-emerald-400'}
                 />
               </div>

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -208,14 +208,32 @@ function fmtBandSpread(band, fmt = (v) => v.toFixed(2)) {
 }
 
 // Module-scope pure helpers — no implicit closure over component state
-function buildElements(compositionUuid, compositions, elements) {
+//
+// computeEffectiveRockStats reads element stats under `element_`-prefixed keys
+// (element_resistance, element_instability, …) but the mineable_elements rows
+// from /api/gamedata/mining carry UNPREFIXED columns (resistance, instability,
+// …). Map them here — without this the join "succeeds" but every stat reads
+// undefined → 0, so resistance/instability deltas are silently inert for every
+// rock (quantainium looks identical to iron).
+export function elementStats(row) {
+  if (!row) return {}
+  return {
+    element_resistance: row.resistance,
+    element_instability: row.instability,
+    element_optimal_window_midpoint: row.optimal_window_midpoint,
+    element_optimal_window_thinness: row.optimal_window_thinness,
+    element_explosion_multiplier: row.explosion_multiplier,
+  }
+}
+
+export function buildElements(compositionUuid, compositions, elements) {
   const comp = compositions.find((c) => c.uuid === compositionUuid)
   if (!comp?.composition_json) return []
   let parsed = []
   try { parsed = JSON.parse(comp.composition_json) } catch { return [] }
   return parsed.map((el) => {
     const match = elements.find((e) => e.class_name?.toLowerCase() === el.element?.toLowerCase())
-    return { ...el, stats: match || {} }
+    return { ...el, stats: elementStats(match) }
   })
 }
 
@@ -357,10 +375,26 @@ export default function RockCalculator({ data }) {
     }
   }, [aggregatedStats, result.mods, result.totalDps, shipScopeParams])
 
-  // Elements list for single-variant display
+  // Elements list for single-variant display. A composition can list the same
+  // element as multiple parts (e.g. CommonShipMineables_Iron has two iron_ore
+  // bands with different quality_scale) — merge them per element for display
+  // (min of mins, max of maxes) so the player sees "Iron Ore" once. The math
+  // (aggregatedStats) still uses the raw per-part breakdown.
   const displayElements = useMemo(() => {
     if (!pick.compositionUuid) return []
-    return buildElements(pick.compositionUuid, compositions, elements)
+    const raw = buildElements(pick.compositionUuid, compositions, elements)
+    const merged = new Map()
+    for (const el of raw) {
+      const key = el.element
+      const prev = merged.get(key)
+      if (!prev) {
+        merged.set(key, { ...el })
+      } else {
+        prev.min_pct = Math.min(prev.min_pct ?? 0, el.min_pct ?? 0)
+        prev.max_pct = Math.max(prev.max_pct ?? 0, el.max_pct ?? 0)
+      }
+    }
+    return [...merged.values()]
   }, [pick.compositionUuid, compositions, elements])
 
   const hasLoadout = Object.values(laserIds).some(Boolean)

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -3,7 +3,7 @@ import { Check, X as XIcon, ChevronDown, Activity } from 'lucide-react'
 import {
   SHIP_PRESETS, MOD_KEYS, MOD_LABELS, MOD_POSITIVE_IS_GOOD,
   computeEffectiveModifiers, formatModPct,
-  friendlyElementName,
+  friendlyElementName, instabilityBand,
 } from './miningUtils'
 import { computeQualityBand } from './computeEffectiveRockStats'
 import { resolveRockEntity, buildMedianBaseByCategory } from './resolveRockEntity'
@@ -85,39 +85,18 @@ function ShipButton({ preset, active, onClick }) {
   )
 }
 
-// Stat card inspired by RockBreaker's stats dashboard
-function StatCard({ label, value, subtitle, color = 'text-sc-accent', glow = false }) {
-  return (
-    <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-      <p className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">{label}</p>
-      <p
-        className={`text-xl font-bold font-mono ${color}`}
-        style={glow ? { textShadow: `0 0 12px currentColor` } : undefined}
-      >
-        {value}
-      </p>
-      {subtitle && <p className="text-[10px] text-gray-600 mt-1 font-mono">{subtitle}</p>}
-    </div>
-  )
-}
-
-function ChargeBar({ windowStart, windowEnd, effectiveInstabilityDelta }) {
+function ChargeBar({ windowStart, windowEnd }) {
   const startPct = windowStart * 100
   const endPct = windowEnd * 100
+  const widthPct = endPct - startPct
   const catStart = 90
-
-  const instabilityLabel = effectiveInstabilityDelta != null
-    ? (effectiveInstabilityDelta >= 0 ? `+${effectiveInstabilityDelta.toFixed(3)}` : effectiveInstabilityDelta.toFixed(3))
-    : '—'
-  const instabilityColor = effectiveInstabilityDelta != null && effectiveInstabilityDelta > 0.2
-    ? 'text-red-400'
-    : effectiveInstabilityDelta != null && effectiveInstabilityDelta > 0.05
-      ? 'text-amber-400'
-      : 'text-emerald-400'
 
   return (
     <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Charge Window</div>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="text-[10px] uppercase tracking-wider text-gray-500">Optimal Charge Zone — release here</div>
+        <div className="text-sm font-mono font-semibold text-emerald-400">{startPct.toFixed(0)}–{endPct.toFixed(0)}%</div>
+      </div>
       <div className="relative h-8 bg-white/[0.04] rounded-full overflow-hidden">
         {/* Background gradient */}
         <div className="absolute inset-0" style={{
@@ -130,25 +109,49 @@ function ChargeBar({ windowStart, windowEnd, effectiveInstabilityDelta }) {
         {/* Optimal window */}
         <div
           className="absolute top-0 bottom-0 bg-emerald-500/30 border-l-2 border-r-2 border-emerald-400/60"
-          style={{ left: `${startPct}%`, width: `${Math.max(endPct - startPct, 0.5)}%` }}
+          style={{ left: `${startPct}%`, width: `${Math.max(widthPct, 0.5)}%` }}
         />
-        {/* Labels */}
         <div className="absolute inset-0 flex items-center px-3 justify-between text-[10px] font-mono">
           <span className="text-gray-500">0%</span>
-          <span className="text-emerald-400 font-semibold bg-black/30 px-2 py-0.5 rounded">
-            {startPct.toFixed(0)}–{endPct.toFixed(0)}%
-          </span>
           <span className="text-gray-500">100%</span>
         </div>
       </div>
-      <div className="flex items-center justify-between mt-2 text-xs">
-        <span className="text-gray-500 font-mono">
-          Window: {(endPct - startPct).toFixed(1)}% wide
-        </span>
-        <span className={`font-mono font-semibold ${instabilityColor}`}>
-          Instability Δ: {instabilityLabel}
-        </span>
+      <p className="text-[11px] text-gray-500 mt-2 leading-relaxed">
+        Hold the beam between <span className="text-gray-300">{startPct.toFixed(0)}%</span> and <span className="text-gray-300">{endPct.toFixed(0)}%</span> charge
+        {widthPct < 8 ? ' — a narrow window, easy to overshoot.' : ', then ease off — past the red zone is a catastrophic shatter.'}
+      </p>
+    </div>
+  )
+}
+
+// Player-facing stability readout: named band + dot + risk phrase + 0–1000
+// gauge, with the raw weighted instability and quality spread as a footnote.
+function StabilityCard({ band, leanInstability, richInstability }) {
+  const showSpread = leanInstability != null && richInstability != null
+    && Math.abs(leanInstability - richInstability) > 1e-6
+  return (
+    <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <span className={`w-2.5 h-2.5 rounded-full ${band.dot}`} />
+          <span className={`text-lg font-bold ${band.text}`}>{band.label}</span>
+        </div>
+        <span className={`text-sm font-mono ${band.text}`}>{band.risk}</span>
       </div>
+      <div className="h-1.5 rounded-full bg-white/[0.06] mt-3 overflow-hidden">
+        <div className={`h-full rounded-full ${band.bar}`} style={{ width: `${band.barPct}%` }} />
+      </div>
+      <p className="text-[11px] text-gray-500 mt-2.5 leading-relaxed">
+        {band.label === 'Stable'   && 'Forgiving — little danger of a catastrophic shatter.'}
+        {band.label === 'Twitchy'  && 'Stay attentive — overcharging will shatter it.'}
+        {band.label === 'Volatile' && 'Dangerous — overcharge even slightly and it shatters.'}
+        {band.label === 'Extreme'  && 'Brutal — the shatter window is unforgiving.'}
+        {' '}Higher-quality (richer) rolls of this rock get more unstable.
+      </p>
+      <p className="text-[10px] text-gray-600 mt-1.5 font-mono">
+        instability {Math.round(band.value)} / 1000
+        {showSpread && <> · lean {Math.round(leanInstability)} → rich {Math.round(richInstability)}</>}
+      </p>
     </div>
   )
 }
@@ -163,7 +166,7 @@ function PowerBar({ totalDps, effectiveResistance, canBreak }) {
 
   return (
     <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Power vs Resistance</div>
+      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Power vs Rock</div>
       <div className="relative h-6 bg-white/[0.04] rounded-full overflow-hidden">
         {/* Power bar */}
         <div
@@ -180,23 +183,17 @@ function PowerBar({ totalDps, effectiveResistance, canBreak }) {
       </div>
       <div className="flex items-center justify-between mt-2 text-xs font-mono">
         <span className="text-gray-400">
-          Your Power: <span className="text-sc-accent">{totalDps.toFixed(1)}</span>
+          Your power <span className="text-sc-accent">{totalDps.toFixed(0)}</span>
         </span>
         <span className={canBreak ? 'text-emerald-400' : 'text-red-400'}>
-          {canBreak ? 'Surplus' : 'Deficit'}: {diffPct.toFixed(1)}%
+          {canBreak ? 'Surplus' : 'Deficit'} {diffPct.toFixed(0)}%
         </span>
         <span className="text-gray-400">
-          Required: <span className="text-amber-400">{effectiveResistance.toFixed(1)}</span>
+          Needs <span className="text-amber-400">{effectiveResistance.toFixed(0)}</span>
         </span>
       </div>
     </div>
   )
-}
-
-/** The avg (expected) value of a quality band, formatted. */
-function fmtBandAvg(band, fmt = (v) => v.toFixed(2)) {
-  if (!band || band.avg == null) return '—'
-  return fmt(band.avg)
 }
 
 /** "Lean X → Rich Y" sub-line for a quality band. Collapses to a single
@@ -205,6 +202,19 @@ function fmtBandSpread(band, fmt = (v) => v.toFixed(2)) {
   if (!band || band.lean == null || band.rich == null) return null
   if (Math.abs(band.lean - band.rich) < 1e-6) return null
   return `Lean ${fmt(band.lean)} → Rich ${fmt(band.rich)}`
+}
+
+/** Plain-language difficulty tag for a composition element, from its signed
+ *  resistance modifier + raw instability. Lets a player read "easy" / "brutal"
+ *  instead of "R:-0.400 I:50.000". */
+function elementDifficultyTag(stats) {
+  const r = stats?.element_resistance
+  const i = stats?.element_instability
+  if (r == null && i == null) return null
+  if ((r ?? 0) >= 0.6 || (i ?? 0) >= 700) return { label: 'brutal', tone: 'text-red-400' }
+  if ((r ?? 0) >= 0.3 || (i ?? 0) >= 400) return { label: 'tough', tone: 'text-orange-400' }
+  if ((r ?? 0) <= -0.3 && (i ?? 0) < 100) return { label: 'easy', tone: 'text-emerald-400' }
+  return { label: 'moderate', tone: 'text-gray-400' }
 }
 
 // Module-scope pure helpers — no implicit closure over component state
@@ -364,6 +374,14 @@ export default function RockCalculator({ data }) {
     const windowEnd = Math.min(1, baseMidpoint + windowSize / 2)
 
     const canBreak = result.totalDps > effectiveResistanceAfterLaser
+    // Margin: how much your power over/under-shoots the rock's resistance.
+    const marginPct = effectiveResistanceAfterLaser > 0
+      ? Math.abs((result.totalDps - effectiveResistanceAfterLaser) / effectiveResistanceAfterLaser) * 100
+      : 0
+
+    const band = instabilityBand(instabilityDelta)
+    const leanInstability = aggregatedStats.band?.effective_instability_delta?.lean
+    const richInstability = aggregatedStats.band?.effective_instability_delta?.rich
 
     return {
       effectiveResistance,
@@ -372,6 +390,10 @@ export default function RockCalculator({ data }) {
       windowStart,
       windowEnd,
       canBreak,
+      marginPct,
+      band,
+      leanInstability,
+      richInstability,
     }
   }, [aggregatedStats, result.mods, result.totalDps, shipScopeParams])
 
@@ -563,6 +585,11 @@ export default function RockCalculator({ data }) {
                       style={{ textShadow: '0 0 20px rgba(52, 211, 153, 0.5)' }}>
                       CAN BREAK
                     </p>
+                    <p className="text-xs text-gray-300 mt-1.5">
+                      Your laser overpowers this rock by{' '}
+                      <span className="text-emerald-400 font-semibold">{displayStats.marginPct.toFixed(0)}%</span>
+                      {displayStats.marginPct < 15 && <span className="text-amber-400"> — tight</span>}
+                    </p>
                   </div>
                 ) : (
                   <div>
@@ -570,6 +597,9 @@ export default function RockCalculator({ data }) {
                     <p className="text-2xl font-bold tracking-wider text-red-400 font-display"
                       style={{ textShadow: '0 0 20px rgba(239, 68, 68, 0.5)' }}>
                       CANNOT BREAK
+                    </p>
+                    <p className="text-xs text-gray-300 mt-1.5">
+                      Short by <span className="text-red-400 font-semibold">{displayStats.marginPct.toFixed(0)}%</span> — needs a stronger laser or modules
                     </p>
                   </div>
                 )}
@@ -586,86 +616,71 @@ export default function RockCalculator({ data }) {
                 )}
               </div>
 
-              {/* Power vs Resistance bar */}
-              <PowerBar
-                totalDps={result.totalDps}
-                effectiveResistance={displayStats.effectiveResistanceAfterLaser}
-                canBreak={displayStats.canBreak}
-              />
-
-              {/* Stats dashboard — RockBreaker-inspired grid */}
-              <div className="grid grid-cols-2 gap-3">
-                <StatCard
-                  label="Total Laser Power"
-                  value={result.totalDps.toFixed(2)}
-                  color="text-sc-accent"
-                  glow
+              {/* Power vs Rock bar (your power vs power-to-fracture) */}
+              <div>
+                <PowerBar
+                  totalDps={result.totalDps}
+                  effectiveResistance={displayStats.effectiveResistanceAfterLaser}
+                  canBreak={displayStats.canBreak}
                 />
-                <StatCard
-                  label="Adjusted Resistance"
-                  value={fmtBandAvg(aggregatedStats?.band?.effective_resistance_after_laser)}
-                  subtitle={
-                    fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser)
-                    ?? (aggregatedStats?.count > 1 ? `${aggregatedStats.count} variants` : 'expected roll')
-                  }
-                  color="text-amber-400"
-                />
-                <StatCard
-                  label="Power Difference"
-                  value={(result.totalDps - displayStats.effectiveResistanceAfterLaser).toFixed(2)}
-                  color={displayStats.canBreak ? 'text-emerald-400' : 'text-red-400'}
-                  glow
-                />
-                <StatCard
-                  label="Instability"
-                  value={fmtBandAvg(aggregatedStats?.band?.effective_instability_delta, (v) => (v >= 0 ? `+${v.toFixed(3)}` : v.toFixed(3)))}
-                  subtitle={
-                    fmtBandSpread(aggregatedStats?.band?.effective_instability_delta, (v) => v.toFixed(3))
-                    ?? 'rises with quality'
-                  }
-                  color={displayStats.instabilityDelta > 0.2 ? 'text-red-400' : displayStats.instabilityDelta > 0.05 ? 'text-amber-400' : 'text-emerald-400'}
-                />
+                {fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser, (v) => v.toFixed(0)) && (
+                  <p className="text-[10px] text-gray-600 mt-1.5 ml-1 font-mono">
+                    power needed by quality — {fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser, (v) => v.toFixed(0))}
+                  </p>
+                )}
               </div>
 
-              {/* Charge window */}
+              {/* Stability — the danger axis, as a named band */}
+              <StabilityCard
+                band={displayStats.band}
+                leanInstability={displayStats.leanInstability}
+                richInstability={displayStats.richInstability}
+              />
+
+              {/* Optimal charge zone */}
               <ChargeBar
                 windowStart={displayStats.windowStart}
                 windowEnd={displayStats.windowEnd}
-                effectiveInstabilityDelta={displayStats.instabilityDelta}
               />
 
-              {/* Rock elements — only shown for specific variant */}
+              {/* What's in it — only shown for a specific variant */}
               {pick.compositionUuid && displayElements.length > 0 && (
                 <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-                  <h4 className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Rock Composition Elements</h4>
+                  <h4 className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">What's in it</h4>
                   <div className="space-y-1.5">
-                    {displayElements.map((el, i) => (
-                      <div key={i} className="flex items-center justify-between text-xs">
-                        <span className="text-gray-300">
-                          {friendlyElementName(el.element)}
-                        </span>
-                        <div className="flex items-center gap-3 text-gray-500 font-mono">
-                          {el.max_pct != null && (
-                            <span>{(el.min_pct ?? 0).toFixed(1)}–{el.max_pct.toFixed(1)}%</span>
-                          )}
-                          {el.stats?.element_resistance != null && (
-                            <span className="text-amber-400/60">R:{el.stats.element_resistance.toFixed(3)}</span>
-                          )}
-                          {el.stats?.element_instability != null && (
-                            <span className="text-red-400/60">I:{el.stats.element_instability.toFixed(3)}</span>
-                          )}
+                    {displayElements.map((el, i) => {
+                      const tag = elementDifficultyTag(el.stats)
+                      return (
+                        <div key={i} className="flex items-center justify-between text-xs">
+                          <span className="text-gray-300">{friendlyElementName(el.element)}</span>
+                          <div className="flex items-center gap-3 font-mono text-gray-500">
+                            {el.max_pct != null && (
+                              <span>{(el.min_pct ?? 0).toFixed(0)}–{el.max_pct.toFixed(0)}%</span>
+                            )}
+                            {tag && <span className={tag.tone}>{tag.label}</span>}
+                            {/* raw modifiers kept for power users */}
+                            {el.stats?.element_resistance != null && (
+                              <span className="text-gray-600">R:{el.stats.element_resistance.toFixed(2)}</span>
+                            )}
+                            {el.stats?.element_instability != null && (
+                              <span className="text-gray-600">I:{el.stats.element_instability.toFixed(0)}</span>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      )
+                    })}
                   </div>
                 </div>
               )}
 
-              {/* Effective modifiers */}
+              {/* Your loadout bonuses — collapsed; power-user detail */}
               {MOD_KEYS.some(k => Math.abs(result.mods[k]) > 0.0001) && (
-                <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-                  <h4 className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Effective Modifiers</h4>
-                  <div className="grid grid-cols-2 gap-2">
+                <details className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg px-4 py-3 group">
+                  <summary className="text-[10px] uppercase tracking-wider text-gray-500 cursor-pointer select-none flex items-center gap-2 list-none">
+                    <ChevronDown className="w-3.5 h-3.5 transition-transform group-open:rotate-180" />
+                    Your laser &amp; module bonuses
+                  </summary>
+                  <div className="grid grid-cols-2 gap-2 mt-3">
                     {MOD_KEYS.map(key => {
                       const val = result.mods[key]
                       if (Math.abs(val) < 0.0001) return null
@@ -680,7 +695,7 @@ export default function RockCalculator({ data }) {
                       )
                     })}
                   </div>
-                </div>
+                </details>
               )}
             </>
           ) : (

--- a/frontend/src/pages/Mining/buildElements.test.js
+++ b/frontend/src/pages/Mining/buildElements.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { elementStats, buildElements } from './RockCalculator'
+import { computeEffectiveRockStats } from './computeEffectiveRockStats'
+
+/**
+ * Regression guard for the field-name mismatch that left element math inert in
+ * production: mineable_elements rows from /api/gamedata/mining carry UNPREFIXED
+ * columns (resistance, instability, …), but computeEffectiveRockStats reads
+ * element_-prefixed keys. buildElements must bridge them.
+ */
+describe('elementStats — maps unprefixed DB columns to element_-prefixed keys', () => {
+  it('maps every consumed stat', () => {
+    const row = {
+      class_name: 'iron_ore',
+      resistance: -0.4,
+      instability: 50,
+      optimal_window_midpoint: 0.6,
+      optimal_window_thinness: -0.9,
+      explosion_multiplier: 20,
+    }
+    expect(elementStats(row)).toEqual({
+      element_resistance: -0.4,
+      element_instability: 50,
+      element_optimal_window_midpoint: 0.6,
+      element_optimal_window_thinness: -0.9,
+      element_explosion_multiplier: 20,
+    })
+  })
+
+  it('returns {} for an unmatched element', () => {
+    expect(elementStats(undefined)).toEqual({})
+    expect(elementStats(null)).toEqual({})
+  })
+})
+
+describe('buildElements → computeEffectiveRockStats integration', () => {
+  // The real-DB shape: composition_json elements joined to unprefixed
+  // mineable_elements rows. This is the path that was silently producing
+  // zero deltas in production.
+  const compositions = [{
+    uuid: 'c-iron',
+    composition_json: JSON.stringify([
+      { element: 'iron_ore', min_pct: 9.7, max_pct: 15.7, probability: 1.0 },
+      { element: 'iron_ore', min_pct: 34.3, max_pct: 84.3, probability: 1.0 },
+    ]),
+  }]
+  const elements = [
+    { class_name: 'iron_ore', resistance: -0.4, instability: 50,
+      optimal_window_midpoint: 0.6, optimal_window_thinness: -0.9, explosion_multiplier: 20 },
+  ]
+
+  it('produces NON-ZERO instability from real-shaped element rows', () => {
+    const built = buildElements('c-iron', compositions, elements)
+    expect(built).toHaveLength(2)
+    // stats must carry the prefixed keys, not be empty
+    expect(built[0].stats.element_instability).toBe(50)
+
+    const stats = computeEffectiveRockStats({
+      rockEntity: { laser_damage_full_value: 2500 },
+      elements: built,
+      globalParams: { resistance_curve_factor: 0.6 },
+      laserMods: { mod_resistance: 0 },
+    })
+    // iron instability 50 × summed weights (~0.72 at midpoint) ≈ 36, definitely not 0
+    expect(stats.effective_instability_delta).toBeGreaterThan(0)
+    // resistance delta is negative for iron (-0.4) → effective below base×global
+    expect(stats.effective_resistance).toBeLessThan(2500 * 0.6)
+  })
+
+  it('distinguishes a high-resistance element from a low one (quantainium vs iron)', () => {
+    const comps = [
+      { uuid: 'iron', composition_json: JSON.stringify([{ element: 'iron_ore', min_pct: 50, max_pct: 50, probability: 1 }]) },
+      { uuid: 'quant', composition_json: JSON.stringify([{ element: 'quantainium_raw', min_pct: 50, max_pct: 50, probability: 1 }]) },
+    ]
+    const els = [
+      { class_name: 'iron_ore', resistance: -0.4, instability: 50 },
+      { class_name: 'quantainium_raw', resistance: 0.95, instability: 1000 },
+    ]
+    const mk = (uuid) => computeEffectiveRockStats({
+      rockEntity: { laser_damage_full_value: 2500 },
+      elements: buildElements(uuid, comps, els),
+      globalParams: { resistance_curve_factor: 0.6 },
+      laserMods: { mod_resistance: 0 },
+    })
+    const iron = mk('iron')
+    const quant = mk('quant')
+    // quantainium must be harder + far more unstable than iron — the whole point
+    expect(quant.effective_resistance).toBeGreaterThan(iron.effective_resistance)
+    expect(quant.effective_instability_delta).toBeGreaterThan(iron.effective_instability_delta)
+  })
+})

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.js
@@ -4,22 +4,35 @@
  *
  * Element stats are SIGNED MODIFIER DELTAS. `??` is used for numeric
  * defaults so legitimate zeros aren't replaced with neutral fallbacks.
+ *
+ * `qualityRoll` (0..1) picks where in each element's [min_pct, max_pct] range
+ * the instance rolled — this is the in-game "quality" axis. 0 = lean roll
+ * (every element at its minimum %), 1 = rich roll (every element at max %),
+ * 0.5 = midpoint (the default; preserves the original per-rock estimate).
+ * Proven from p4k: difficulty and quality co-ride this roll — richer rolls of
+ * valuable elements carry higher resistance and (especially) instability.
+ * See reference_sc_mining_quality_difficulty_mechanism.
  */
 export function computeEffectiveRockStats({
   rockEntity,
   elements,
   globalParams,
   laserMods,
+  qualityRoll = 0.5,
 }) {
   if (!rockEntity || rockEntity.laser_damage_full_value == null) return null
   const safe = (v) => (typeof v === 'number' ? v : 0)
+  const q = Math.min(1, Math.max(0, qualityRoll ?? 0.5))
 
   let totalWeight = 0
   const weights = []
   for (const el of elements ?? []) {
-    const mid = ((el.min_pct ?? 0) + (el.max_pct ?? 0)) / 2 / 100
+    const lo = el.min_pct ?? 0
+    const hi = el.max_pct ?? 0
+    // lerp(lo, hi, q): q=0 → lean (min%), q=1 → rich (max%), q=0.5 → midpoint
+    const pct = (lo + (hi - lo) * q) / 100
     const prob = el.probability ?? 1.0
-    const weight = mid * prob
+    const weight = pct * prob
     weights.push({ element: el.element, weight, stats: el.stats ?? {} })
     totalWeight += weight
   }
@@ -54,5 +67,24 @@ export function computeEffectiveRockStats({
     effective_explosion_delta: explosionDelta,
     weights,
     total_weight: totalWeight,
+  }
+}
+
+/**
+ * Sample the quality band for a single rock: lean (qualityRoll=0), avg (0.5),
+ * rich (1.0). Returns { lean, avg, rich } where each is a full
+ * computeEffectiveRockStats result, or null if the rock can't be resolved.
+ *
+ * The avg point is the expected rock (drives can-break / charge math); lean
+ * and rich bracket the difficulty envelope a player will actually encounter
+ * across quality rolls of this composition.
+ */
+export function computeQualityBand(args) {
+  const avg = computeEffectiveRockStats({ ...args, qualityRoll: 0.5 })
+  if (!avg) return null
+  return {
+    lean: computeEffectiveRockStats({ ...args, qualityRoll: 0 }),
+    avg,
+    rich: computeEffectiveRockStats({ ...args, qualityRoll: 1 }),
   }
 }

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeEffectiveRockStats } from './computeEffectiveRockStats'
+import { computeEffectiveRockStats, computeQualityBand } from './computeEffectiveRockStats'
 
 function ce({ element, min_pct, max_pct, probability = 1.0, ...stats }) {
   return {
@@ -97,5 +97,80 @@ describe('computeEffectiveRockStats', () => {
     })
     expect(result.effective_instability_delta).toBeCloseTo(0.3, 4)
     expect(result.effective_window_midpoint_delta).toBeCloseTo(0.1, 4)
+  })
+
+  describe('qualityRoll (quality band)', () => {
+    // tin: instability 50, resistance 0.2, 20-60% range
+    const tinRock = (qualityRoll) => computeEffectiveRockStats({
+      rockEntity: { laser_damage_full_value: 1000 },
+      elements: [ce({ element: 'tin', min_pct: 20, max_pct: 60, probability: 1.0,
+                       element_resistance: 0.2, element_instability: 50 })],
+      globalParams: GLOBAL_SHIP,
+      laserMods: { mod_resistance: 0 },
+      qualityRoll,
+    })
+
+    it('qualityRoll=0 uses min_pct (lean roll)', () => {
+      // weight = 0.20 * 1.0 = 0.20 → resistance = 1000 * (1 + 0.2*0.20) = 1040
+      expect(tinRock(0).effective_resistance).toBeCloseTo(1040, 0)
+      // instability = 50 * 0.20 = 10
+      expect(tinRock(0).effective_instability_delta).toBeCloseTo(10, 4)
+    })
+
+    it('qualityRoll=1 uses max_pct (rich roll)', () => {
+      // weight = 0.60 * 1.0 = 0.60 → resistance = 1000 * (1 + 0.2*0.60) = 1120
+      expect(tinRock(1).effective_resistance).toBeCloseTo(1120, 0)
+      // instability = 50 * 0.60 = 30
+      expect(tinRock(1).effective_instability_delta).toBeCloseTo(30, 4)
+    })
+
+    it('default (omitted) qualityRoll equals 0.5 midpoint', () => {
+      const omitted = computeEffectiveRockStats({
+        rockEntity: { laser_damage_full_value: 1000 },
+        elements: [ce({ element: 'tin', min_pct: 20, max_pct: 60, probability: 1.0,
+                         element_resistance: 0.2, element_instability: 50 })],
+        globalParams: GLOBAL_SHIP,
+        laserMods: { mod_resistance: 0 },
+      })
+      expect(omitted.effective_resistance).toBeCloseTo(tinRock(0.5).effective_resistance, 6)
+      expect(omitted.effective_instability_delta).toBeCloseTo(tinRock(0.5).effective_instability_delta, 6)
+    })
+
+    it('rich roll raises instability above lean roll (the quality→difficulty signal)', () => {
+      expect(tinRock(1).effective_instability_delta).toBeGreaterThan(tinRock(0).effective_instability_delta)
+    })
+
+    it('clamps qualityRoll outside [0,1]', () => {
+      expect(tinRock(5).effective_instability_delta).toBeCloseTo(tinRock(1).effective_instability_delta, 6)
+      expect(tinRock(-3).effective_instability_delta).toBeCloseTo(tinRock(0).effective_instability_delta, 6)
+    })
+  })
+})
+
+describe('computeQualityBand', () => {
+  const args = {
+    rockEntity: { laser_damage_full_value: 2000 },
+    elements: [{
+      element: 'quant', min_pct: 20, max_pct: 50, probability: 1.0,
+      stats: { element_resistance: 0.95, element_instability: 1000,
+               element_optimal_window_midpoint: 0, element_optimal_window_thinness: 0,
+               element_explosion_multiplier: 0 },
+    }],
+    globalParams: { resistance_curve_factor: 1.0 },
+    laserMods: { mod_resistance: 0 },
+  }
+
+  it('returns lean / avg / rich sampled at qualityRoll 0 / 0.5 / 1', () => {
+    const band = computeQualityBand(args)
+    expect(band).not.toBeNull()
+    // rich instability (50% quant) > avg (35%) > lean (20%) — strictly increasing
+    expect(band.rich.effective_instability_delta).toBeGreaterThan(band.avg.effective_instability_delta)
+    expect(band.avg.effective_instability_delta).toBeGreaterThan(band.lean.effective_instability_delta)
+    // resistance climbs too for this high-resistance element
+    expect(band.rich.effective_resistance).toBeGreaterThan(band.lean.effective_resistance)
+  })
+
+  it('returns null when the rock cannot be resolved', () => {
+    expect(computeQualityBand({ ...args, rockEntity: null })).toBeNull()
   })
 })

--- a/frontend/src/pages/Mining/instabilityBand.test.js
+++ b/frontend/src/pages/Mining/instabilityBand.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { instabilityBand } from './miningUtils'
+
+describe('instabilityBand', () => {
+  it('classifies the four bands by threshold', () => {
+    expect(instabilityBand(36).label).toBe('Stable')      // iron-ish
+    expect(instabilityBand(99).label).toBe('Stable')
+    expect(instabilityBand(100).label).toBe('Twitchy')
+    expect(instabilityBand(399).label).toBe('Twitchy')
+    expect(instabilityBand(400).label).toBe('Volatile')
+    expect(instabilityBand(699).label).toBe('Volatile')
+    expect(instabilityBand(700).label).toBe('Extreme')
+    expect(instabilityBand(1000).label).toBe('Extreme')   // quantainium-ish
+  })
+
+  it('carries a player-facing risk phrase + colour tokens', () => {
+    const b = instabilityBand(36)
+    expect(b.risk).toBe('low shatter risk')
+    expect(b.text).toMatch(/emerald/)
+    expect(b.dot).toMatch(/emerald/)
+  })
+
+  it('maps value to a 0–100% bar, clamped', () => {
+    expect(instabilityBand(0).barPct).toBe(0)
+    expect(instabilityBand(500).barPct).toBe(50)
+    expect(instabilityBand(2000).barPct).toBe(100) // clamped
+  })
+
+  it('treats null/undefined as 0 → Stable', () => {
+    expect(instabilityBand(null).label).toBe('Stable')
+    expect(instabilityBand(undefined).label).toBe('Stable')
+    expect(instabilityBand(null).barPct).toBe(0)
+  })
+})

--- a/frontend/src/pages/Mining/miningUtils.js
+++ b/frontend/src/pages/Mining/miningUtils.js
@@ -164,6 +164,24 @@ export function friendlyCompositionName(raw) {
   return s
 }
 
+// Classify a weighted instability value (0–1000 scale) into a player-facing
+// danger band. Thresholds align with the existing instabilityColor cutoffs
+// (400 / 700) plus a Stable/Twitchy split at 100. `barPct` is for a 0–100%
+// gauge. Used by the Rock Calculator results panel so a raw "+36" reads as
+// "Stable · low shatter risk" instead of an opaque number.
+const INSTABILITY_BANDS = [
+  { max: 100, label: 'Stable',   risk: 'low shatter risk',      text: 'text-emerald-400', dot: 'bg-emerald-400', bar: 'bg-emerald-500' },
+  { max: 400, label: 'Twitchy',  risk: 'moderate shatter risk', text: 'text-yellow-400',  dot: 'bg-yellow-400',  bar: 'bg-yellow-500' },
+  { max: 700, label: 'Volatile', risk: 'high shatter risk',     text: 'text-orange-400',  dot: 'bg-orange-400',  bar: 'bg-orange-500' },
+  { max: Infinity, label: 'Extreme', risk: 'extreme shatter risk', text: 'text-red-400', dot: 'bg-red-400', bar: 'bg-red-500' },
+]
+
+export function instabilityBand(val) {
+  const v = typeof val === 'number' ? val : 0
+  const band = INSTABILITY_BANDS.find((b) => v < b.max) ?? INSTABILITY_BANDS[INSTABILITY_BANDS.length - 1]
+  return { ...band, value: v, barPct: Math.max(0, Math.min(100, (v / 1000) * 100)) }
+}
+
 // --- Instability color helpers ---
 export function instabilityColor(val) {
   if (val == null) return 'text-gray-400'


### PR DESCRIPTION
## Why

Gavin: *"it appears that how difficult a rock is to crack also has to do with its quality."* The p4k deep-dive (see reference_sc_mining_quality_difficulty_mechanism) proved difficulty and quality co-ride the composition roll — there's no quality→resistance multiplier in the data, but richer rolls of valuable elements carry higher resistance and (especially) **instability**. This surfaces that envelope.

## What

- `computeEffectiveRockStats` gains a `qualityRoll` (0..1) param: lerps each element's % between `min_pct` (lean, q=0) and `max_pct` (rich, q=1). Default `0.5` = the original midpoint estimate, so all prior behaviour + tests are unchanged.
- New `computeQualityBand(args)` samples lean/avg/rich (qualityRoll 0 / 0.5 / 1) → `{ lean, avg, rich }`.
- `RockCalculator` `aggregatedStats` restructured to a per-stat `band { lean, avg, rich }` (averaged across variants in generic deposit mode). The `avg` point drives can-break / charge math; lean→rich is shown as a band per stat.
- Resistance + Instability StatCards now show the expected value with a `Lean X → Rich Y` sub-line, always visible. Instability relabelled (it's the steepest quality-tracking axis).

## Test plan

- [x] `computeEffectiveRockStats.test.js` — 13 pass (6 original unchanged + 7 new: qualityRoll min/max/default/clamp, band lean<avg<rich, null guard)
- [x] frontend `vitest run` — 305 pass
- [x] typecheck clean, `npm run build` OK
- [ ] visual smoke on staging

## Notes

No migrations, no backend change — pure frontend math + display. Faithful to the proven mechanism; no invented multiplier.