### PR TITLE
feat(rock-calc): URL deep-links + saved ship loadouts

### DIFF
--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react'
-import { Check, X as XIcon, ChevronDown, Activity } from 'lucide-react'
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Check, X as XIcon, ChevronDown, Activity, Save, Trash2 } from 'lucide-react'
 import {
   SHIP_PRESETS, MOD_KEYS, MOD_LABELS, MOD_POSITIVE_IS_GOOD,
   computeEffectiveModifiers, formatModPct,
@@ -7,6 +8,13 @@ import {
 } from './miningUtils'
 import { computeQualityBand } from './computeEffectiveRockStats'
 import { resolveRockEntity, buildMedianBaseByCategory } from './resolveRockEntity'
+import { encodeLoadoutParams, decodeLoadoutParams } from './loadoutCodec'
+import {
+  serializeLoadout, resolveLoadout, upsertLoadout, removeLoadout,
+  readLocalLoadouts, writeLocalLoadouts,
+} from './loadoutStore'
+import { useSession } from '../../lib/auth-client'
+import { usePreferences, setPreferences } from '../../hooks/useAPI'
 import DepositPicker from './DepositPicker'
 
 // Custom styled select replacing native <select>
@@ -261,6 +269,92 @@ export default function RockCalculator({ data }) {
   const gadgets = data?.gadgets || []
   const compositions = data?.compositions || []
   const elements = data?.elements || []
+
+  // ── Deep-link: hydrate state from the URL once data is available, then keep
+  //    the URL in sync as the loadout/rock changes (shareable scenario). We
+  //    only touch our own keys so the parent's `tab` param is preserved.
+  const [searchParams, setSearchParams] = useSearchParams()
+  // `hydrated` is state (not a ref) so the URL-writer below only runs on the
+  // render AFTER hydration — the hydrated values are applied in the same batch
+  // as setHydrated(true), so the writer never clobbers the incoming link with
+  // default state first.
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => {
+    if (hydrated || !data) return
+    const decoded = decodeLoadoutParams(searchParams, data, SHIP_PRESETS.length)
+    if (decoded) {
+      setShipIndex(decoded.shipIndex)
+      setLaserIds(decoded.laserIds)
+      setModuleIds(decoded.moduleIds)
+      setGadget(decoded.gadget)
+      setPick(decoded.pick)
+    }
+    setHydrated(true)
+  }, [data, searchParams, hydrated])
+
+  useEffect(() => {
+    if (!hydrated) return
+    const next = encodeLoadoutParams({ shipIndex, laserIds, moduleIds, gadget, pick })
+    setSearchParams((prev) => {
+      const merged = new URLSearchParams(prev)
+      // Drop our keys, then re-add the current set (so removals clear from URL).
+      for (const k of [...merged.keys()]) {
+        if (k === 'ship' || k === 'gadget' || k === 'rock' || k === 'el'
+            || /^l\d+$/.test(k) || /^m\d+-\d+$/.test(k)) merged.delete(k)
+      }
+      for (const [k, v] of Object.entries(next)) merged.set(k, v)
+      return merged
+    }, { replace: true })
+  }, [hydrated, shipIndex, laserIds, moduleIds, gadget, pick, setSearchParams])
+
+  // ── Saved loadouts: account-backed when logged in, localStorage otherwise.
+  const { data: session } = useSession()
+  const isLoggedIn = !!session?.user
+  const { data: prefs } = usePreferences({ skip: !isLoggedIn })
+  const [loadouts, setLoadouts] = useState([])
+  const [loadoutName, setLoadoutName] = useState('')
+
+  // Load saved loadouts from the right source once we know auth state.
+  useEffect(() => {
+    if (isLoggedIn) {
+      if (prefs === null) return // still loading
+      try {
+        const arr = prefs?.miningLoadouts ? JSON.parse(prefs.miningLoadouts) : []
+        setLoadouts(Array.isArray(arr) ? arr : [])
+      } catch { setLoadouts([]) }
+    } else {
+      setLoadouts(readLocalLoadouts())
+    }
+  }, [isLoggedIn, prefs])
+
+  const persistLoadouts = useCallback((next) => {
+    setLoadouts(next)
+    if (isLoggedIn) {
+      setPreferences({ miningLoadouts: next.length ? JSON.stringify(next) : null })
+        .catch((err) => console.error('[mining] save loadouts failed:', err))
+    } else {
+      writeLocalLoadouts(next)
+    }
+  }, [isLoggedIn])
+
+  const saveCurrentLoadout = useCallback(() => {
+    const name = loadoutName.trim()
+    if (!name) return
+    persistLoadouts(upsertLoadout(loadouts, serializeLoadout(name, { shipIndex, laserIds, moduleIds, gadget })))
+    setLoadoutName('')
+  }, [loadoutName, loadouts, shipIndex, laserIds, moduleIds, gadget, persistLoadouts])
+
+  const applyLoadout = useCallback((entry) => {
+    const r = resolveLoadout(entry, data)
+    setShipIndex(r.shipIndex)
+    setLaserIds(r.laserIds)
+    setModuleIds(r.moduleIds)
+    setGadget(r.gadget)
+  }, [data])
+
+  const deleteLoadout = useCallback((name) => {
+    persistLoadouts(removeLoadout(loadouts, name))
+  }, [loadouts, persistLoadouts])
 
   // Show every composition that has a deposit_name. Comps without a direct
   // mineable_rock_entities row (the CommonShipMineables_X shared templates)
@@ -559,6 +653,60 @@ export default function RockCalculator({ data }) {
           <div className="relative z-10 bg-white/[0.03] border border-white/[0.06] rounded-xl p-5">
             <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-3 font-display">Rock</h3>
             <DepositPicker compositions={pickerCompositions} value={pick} onChange={setPick} />
+          </div>
+
+          {/* Saved loadouts — save the current ship config, reload it later.
+              Backed by your account when logged in, otherwise this browser. */}
+          <div className="relative z-0 bg-white/[0.03] border border-white/[0.06] rounded-xl p-5">
+            <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-3 font-display">Saved Loadouts</h3>
+
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={loadoutName}
+                onChange={(e) => setLoadoutName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') saveCurrentLoadout() }}
+                placeholder="Name this loadout…"
+                maxLength={40}
+                className="flex-1 min-w-0 px-3 py-2 rounded-lg text-sm bg-white/[0.03] border border-white/[0.08] text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-sc-accent/40"
+              />
+              <button
+                type="button"
+                onClick={saveCurrentLoadout}
+                disabled={!loadoutName.trim() || !Object.values(laserIds).some(Boolean)}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium bg-sc-accent/15 text-sc-accent border border-sc-accent/30 hover:bg-sc-accent/25 disabled:opacity-40 disabled:cursor-not-allowed transition-colors cursor-pointer"
+              >
+                <Save className="w-3.5 h-3.5" /> Save
+              </button>
+            </div>
+
+            {loadouts.length > 0 && (
+              <div className="mt-3 space-y-1.5">
+                <p className="text-[10px] uppercase tracking-wider text-gray-600">
+                  {isLoggedIn ? 'Saved to your account' : 'Saved in this browser'}
+                </p>
+                {loadouts.map((lo) => (
+                  <div key={lo.name} className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => applyLoadout(lo)}
+                      className="flex-1 min-w-0 text-left px-3 py-2 rounded-lg text-xs bg-white/[0.03] border border-white/[0.06] text-gray-300 hover:bg-white/[0.06] hover:text-white transition-colors cursor-pointer truncate"
+                    >
+                      {lo.name}
+                      <span className="text-gray-600 ml-2">{SHIP_PRESETS[lo.ship]?.name ?? 'Ship'}</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteLoadout(lo.name)}
+                      aria-label={`Delete ${lo.name}`}
+                      className="p-2 rounded-lg text-gray-600 hover:text-red-400 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/Mining/loadoutCodec.js
+++ b/frontend/src/pages/Mining/loadoutCodec.js
@@ -1,0 +1,67 @@
+/**
+ * URL <-> Rock Calculator state codec.
+ *
+ * The calculator's full scenario is encoded into the query string so a link
+ * reproduces it exactly (deep-linkable + shareable). Selections are stored by
+ * id (lasers/modules/gadget) and by uuid/name (rock pick), then resolved back
+ * against the live `/api/gamedata/mining` data on decode — so a stale link
+ * whose ids drifted across a patch degrades gracefully (missing pieces just
+ * drop out) instead of throwing.
+ *
+ * Param scheme:
+ *   ship   — ship preset index
+ *   l<i>   — laser id in slot i           (l0, l1, l2)
+ *   m<i>-<j> — module id in laser i slot j (m0-0, m0-1)
+ *   gadget — gadget id
+ *   rock   — deposit_name of the picked rock
+ *   el     — composition uuid (dominant-element drill-in)
+ */
+
+export function encodeLoadoutParams({ shipIndex, laserIds, moduleIds, gadget, pick }) {
+  const p = { ship: String(shipIndex ?? 0) }
+  for (const [slot, laser] of Object.entries(laserIds ?? {})) {
+    if (laser?.id != null) p[`l${slot}`] = String(laser.id)
+  }
+  for (const [key, mod] of Object.entries(moduleIds ?? {})) {
+    if (mod?.id != null) p[`m${key}`] = String(mod.id)
+  }
+  if (gadget?.id != null) p.gadget = String(gadget.id)
+  if (pick?.depositName) p.rock = pick.depositName
+  if (pick?.compositionUuid) p.el = pick.compositionUuid
+  return p
+}
+
+export function decodeLoadoutParams(searchParams, data, shipCount = Infinity) {
+  // Treat as "no loadout in URL" only when none of our keys are present.
+  const hasAny = ['ship', 'gadget', 'rock', 'el'].some((k) => searchParams.has(k))
+    || [...searchParams.keys()].some((k) => /^l\d+$/.test(k) || /^m\d+-\d+$/.test(k))
+  if (!hasAny) return null
+
+  const byId = (list, id) => (list ?? []).find((x) => String(x.id) === String(id)) ?? null
+
+  let shipIndex = parseInt(searchParams.get('ship') ?? '0', 10)
+  if (!Number.isFinite(shipIndex) || shipIndex < 0 || shipIndex >= shipCount) shipIndex = 0
+
+  const laserIds = {}
+  const moduleIds = {}
+  for (const [k, v] of searchParams.entries()) {
+    const lm = k.match(/^l(\d+)$/)
+    if (lm) {
+      const laser = byId(data?.lasers, v)
+      if (laser) laserIds[Number(lm[1])] = laser
+      continue
+    }
+    const mm = k.match(/^m(\d+-\d+)$/)
+    if (mm) {
+      const mod = byId(data?.modules, v)
+      if (mod) moduleIds[mm[1]] = mod
+    }
+  }
+
+  const gadget = searchParams.has('gadget') ? byId(data?.gadgets, searchParams.get('gadget')) : null
+
+  const depositName = searchParams.get('rock') || null
+  const compositionUuid = searchParams.get('el') || null
+
+  return { shipIndex, laserIds, moduleIds, gadget, pick: { depositName, compositionUuid } }
+}

--- a/frontend/src/pages/Mining/loadoutCodec.test.js
+++ b/frontend/src/pages/Mining/loadoutCodec.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { encodeLoadoutParams, decodeLoadoutParams } from './loadoutCodec'
+
+// Minimal mining `data` shape for id resolution.
+const data = {
+  lasers: [{ id: 10, name: 'Helix II', size: 2, module_slots: 2 }, { id: 11, name: 'Lancet', size: 2, module_slots: 1 }],
+  modules: [{ id: 50, name: 'Rime' }, { id: 51, name: 'Surge' }],
+  gadgets: [{ id: 90, name: 'Sabir' }],
+  compositions: [{ uuid: 'c-iron', deposit_name: 'Iron (Ore)' }],
+}
+
+describe('encodeLoadoutParams', () => {
+  it('encodes ship, lasers, modules, gadget and rock pick by id', () => {
+    const p = encodeLoadoutParams({
+      shipIndex: 1,
+      laserIds: { 0: { id: 10 } },
+      moduleIds: { '0-0': { id: 50 }, '0-1': { id: 51 } },
+      gadget: { id: 90 },
+      pick: { depositName: 'Iron (Ore)', compositionUuid: 'c-iron' },
+    })
+    expect(p).toEqual({
+      ship: '1',
+      l0: '10',
+      'm0-0': '50',
+      'm0-1': '51',
+      gadget: '90',
+      rock: 'Iron (Ore)',
+      el: 'c-iron',
+    })
+  })
+
+  it('omits empty selections', () => {
+    const p = encodeLoadoutParams({
+      shipIndex: 0, laserIds: {}, moduleIds: {}, gadget: null, pick: { depositName: null, compositionUuid: null },
+    })
+    expect(p).toEqual({ ship: '0' })
+  })
+})
+
+describe('decodeLoadoutParams', () => {
+  it('round-trips an encoded loadout back to selections', () => {
+    const encoded = encodeLoadoutParams({
+      shipIndex: 1,
+      laserIds: { 0: { id: 10 } },
+      moduleIds: { '0-0': { id: 50 }, '0-1': { id: 51 } },
+      gadget: { id: 90 },
+      pick: { depositName: 'Iron (Ore)', compositionUuid: 'c-iron' },
+    })
+    const sp = new URLSearchParams(encoded)
+    const out = decodeLoadoutParams(sp, data)
+    expect(out.shipIndex).toBe(1)
+    expect(out.laserIds[0]).toMatchObject({ id: 10 })
+    expect(out.moduleIds['0-0']).toMatchObject({ id: 50 })
+    expect(out.moduleIds['0-1']).toMatchObject({ id: 51 })
+    expect(out.gadget).toMatchObject({ id: 90 })
+    expect(out.pick).toEqual({ depositName: 'Iron (Ore)', compositionUuid: 'c-iron' })
+  })
+
+  it('returns null when no loadout params present', () => {
+    expect(decodeLoadoutParams(new URLSearchParams('tab=calculator'), data)).toBeNull()
+  })
+
+  it('ignores ids that no longer exist in data (patch drift) without throwing', () => {
+    const sp = new URLSearchParams({ ship: '0', l0: '999', 'm0-0': '888', gadget: '777' })
+    const out = decodeLoadoutParams(sp, data)
+    expect(out.shipIndex).toBe(0)
+    expect(out.laserIds[0]).toBeUndefined()
+    expect(out.moduleIds['0-0']).toBeUndefined()
+    expect(out.gadget).toBeNull()
+  })
+
+  it('clamps an out-of-range ship index to 0', () => {
+    const sp = new URLSearchParams({ ship: '99' })
+    expect(decodeLoadoutParams(sp, data, 5).shipIndex).toBe(0)
+  })
+})

--- a/frontend/src/pages/Mining/loadoutStore.js
+++ b/frontend/src/pages/Mining/loadoutStore.js
@@ -1,0 +1,85 @@
+/**
+ * Saved Rock Calculator loadouts.
+ *
+ * A loadout is the reusable *ship config* — ship preset + lasers + modules +
+ * gadget — WITHOUT the rock (the rock is what you test against, not part of
+ * the build). Stored as a compact id-only shape so it survives in localStorage
+ * (anonymous users) or a user_settings JSON-array string (logged-in users).
+ * Resolved back to live objects against `/api/gamedata/mining` data on load,
+ * dropping ids that no longer exist after a patch.
+ */
+
+export const LOCAL_KEY = 'scbridge:mining:loadouts'
+export const MAX_LOADOUTS = 20
+
+/** Current calculator state -> compact, persistable entry (ids only, no rock). */
+export function serializeLoadout(name, { shipIndex, laserIds, moduleIds, gadget }) {
+  const laserIdMap = {}
+  for (const [slot, laser] of Object.entries(laserIds ?? {})) {
+    if (laser?.id != null) laserIdMap[slot] = laser.id
+  }
+  const moduleIdMap = {}
+  for (const [key, mod] of Object.entries(moduleIds ?? {})) {
+    if (mod?.id != null) moduleIdMap[key] = mod.id
+  }
+  return {
+    name: String(name).trim(),
+    ship: shipIndex ?? 0,
+    laserIds: laserIdMap,
+    moduleIds: moduleIdMap,
+    gadget: gadget?.id ?? null,
+  }
+}
+
+/** Saved entry -> live selections, resolving ids against current mining data. */
+export function resolveLoadout(entry, data) {
+  const byId = (list, id) => (list ?? []).find((x) => String(x.id) === String(id)) ?? null
+  const laserIds = {}
+  for (const [slot, id] of Object.entries(entry?.laserIds ?? {})) {
+    const laser = byId(data?.lasers, id)
+    if (laser) laserIds[slot] = laser
+  }
+  const moduleIds = {}
+  for (const [key, id] of Object.entries(entry?.moduleIds ?? {})) {
+    const mod = byId(data?.modules, id)
+    if (mod) moduleIds[key] = mod
+  }
+  return {
+    shipIndex: entry?.ship ?? 0,
+    laserIds,
+    moduleIds,
+    gadget: entry?.gadget != null ? byId(data?.gadgets, entry.gadget) : null,
+  }
+}
+
+/** Add or replace (by case-insensitive name); cap to MAX_LOADOUTS, oldest first. */
+export function upsertLoadout(list, entry) {
+  const lc = entry.name.toLowerCase()
+  const without = (list ?? []).filter((l) => l.name.toLowerCase() !== lc)
+  const next = [...without, entry]
+  return next.length > MAX_LOADOUTS ? next.slice(next.length - MAX_LOADOUTS) : next
+}
+
+export function removeLoadout(list, name) {
+  const lc = String(name).toLowerCase()
+  return (list ?? []).filter((l) => l.name.toLowerCase() !== lc)
+}
+
+export function readLocalLoadouts() {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY)
+    if (!raw) return []
+    const arr = JSON.parse(raw)
+    return Array.isArray(arr) ? arr : []
+  } catch {
+    return []
+  }
+}
+
+export function writeLocalLoadouts(list) {
+  try {
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(list ?? []))
+  } catch {
+    /* quota / disabled storage — non-fatal */
+  }
+}

--- a/frontend/src/pages/Mining/loadoutStore.test.js
+++ b/frontend/src/pages/Mining/loadoutStore.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  serializeLoadout, resolveLoadout, upsertLoadout, removeLoadout,
+  readLocalLoadouts, writeLocalLoadouts, LOCAL_KEY, MAX_LOADOUTS,
+} from './loadoutStore'
+
+const data = {
+  lasers: [{ id: 10, name: 'Helix II', size: 2, module_slots: 2 }],
+  modules: [{ id: 50, name: 'Rime' }, { id: 51, name: 'Surge' }],
+  gadgets: [{ id: 90, name: 'Sabir' }],
+}
+
+describe('serializeLoadout / resolveLoadout', () => {
+  it('serializes selections to a compact id-only shape (no rock)', () => {
+    const entry = serializeLoadout('My MOLE', {
+      shipIndex: 1,
+      laserIds: { 0: { id: 10 } },
+      moduleIds: { '0-0': { id: 50 }, '0-1': { id: 51 } },
+      gadget: { id: 90 },
+      pick: { depositName: 'Iron (Ore)' }, // must NOT be saved
+    })
+    expect(entry).toEqual({
+      name: 'My MOLE', ship: 1, laserIds: { 0: 10 }, moduleIds: { '0-0': 50, '0-1': 51 }, gadget: 90,
+    })
+    expect(JSON.stringify(entry)).not.toContain('Iron')
+  })
+
+  it('resolves a saved entry back to live objects against data', () => {
+    const entry = { name: 'X', ship: 1, laserIds: { 0: 10 }, moduleIds: { '0-0': 50 }, gadget: 90 }
+    const r = resolveLoadout(entry, data)
+    expect(r.shipIndex).toBe(1)
+    expect(r.laserIds[0]).toMatchObject({ id: 10 })
+    expect(r.moduleIds['0-0']).toMatchObject({ id: 50 })
+    expect(r.gadget).toMatchObject({ id: 90 })
+  })
+
+  it('drops ids missing from current data (patch drift)', () => {
+    const entry = { name: 'X', ship: 0, laserIds: { 0: 999 }, moduleIds: { '0-0': 888 }, gadget: 777 }
+    const r = resolveLoadout(entry, data)
+    expect(r.laserIds[0]).toBeUndefined()
+    expect(r.moduleIds['0-0']).toBeUndefined()
+    expect(r.gadget).toBeNull()
+  })
+})
+
+describe('upsertLoadout / removeLoadout', () => {
+  it('appends a new named loadout', () => {
+    const out = upsertLoadout([], { name: 'A', ship: 0 })
+    expect(out).toHaveLength(1)
+  })
+  it('replaces an existing loadout with the same name (case-insensitive)', () => {
+    const out = upsertLoadout([{ name: 'A', ship: 0 }], { name: 'a', ship: 2 })
+    expect(out).toHaveLength(1)
+    expect(out[0].ship).toBe(2)
+  })
+  it('caps the list at MAX_LOADOUTS, dropping the oldest', () => {
+    let list = []
+    for (let i = 0; i < MAX_LOADOUTS + 3; i++) list = upsertLoadout(list, { name: `L${i}`, ship: 0 })
+    expect(list).toHaveLength(MAX_LOADOUTS)
+    expect(list[0].name).toBe('L3') // first 3 dropped
+  })
+  it('removes by name', () => {
+    expect(removeLoadout([{ name: 'A' }, { name: 'B' }], 'A')).toEqual([{ name: 'B' }])
+  })
+})
+
+describe('localStorage adapter', () => {
+  beforeEach(() => localStorage.clear())
+  it('writes and reads back an array', () => {
+    writeLocalLoadouts([{ name: 'A', ship: 1 }])
+    expect(readLocalLoadouts()).toEqual([{ name: 'A', ship: 1 }])
+    expect(localStorage.getItem(LOCAL_KEY)).toContain('"name":"A"')
+  })
+  it('returns [] for missing / corrupt storage', () => {
+    expect(readLocalLoadouts()).toEqual([])
+    localStorage.setItem(LOCAL_KEY, 'not json{')
+    expect(readLocalLoadouts()).toEqual([])
+  })
+})

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -181,6 +181,10 @@ export function settingsRoutes() {
       stealthPercent: z.string().max(5).optional(),
       sidebarCollapsed: z.enum(['0', '1']).optional(),
       publicFleetShare: z.enum(['true']).nullable().optional(),
+      // Saved Rock Calculator loadouts — a JSON array string, persisted per
+      // account for logged-in users (anonymous users keep theirs in
+      // localStorage). Capped to keep the KV value sane.
+      miningLoadouts: z.string().max(20000).nullable().optional(),
     }).strict()),
     async (c) => {
     const db = c.env.DB;

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -42,6 +42,45 @@ describe("Settings — /api/settings/preferences", () => {
       expect(body.privacyMode).toBe("hidden");
     });
 
+    it("stores and retrieves miningLoadouts (JSON array string)", async () => {
+      const { sessionToken } = await createTestUser(env.DB);
+      const headers = await authHeaders(sessionToken);
+
+      const loadouts = JSON.stringify([
+        { name: "My MOLE", ship: 1, laserIds: { 0: 12 }, moduleIds: { "0-0": 5 }, gadget: 3 },
+      ]);
+      const putRes = await SELF.fetch("http://localhost/api/settings/preferences", {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ miningLoadouts: loadouts }),
+      });
+      expect(putRes.status).toBe(200);
+
+      const getRes = await SELF.fetch("http://localhost/api/settings/preferences", { headers });
+      const body = (await getRes.json()) as Record<string, string>;
+      expect(body.miningLoadouts).toBe(loadouts);
+      // round-trips back to a usable array
+      expect(JSON.parse(body.miningLoadouts)[0].name).toBe("My MOLE");
+    });
+
+    it("clears miningLoadouts when set to null", async () => {
+      const { sessionToken } = await createTestUser(env.DB);
+      const headers = await authHeaders(sessionToken);
+      await SELF.fetch("http://localhost/api/settings/preferences", {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ miningLoadouts: "[]" }),
+      });
+      await SELF.fetch("http://localhost/api/settings/preferences", {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ miningLoadouts: null }),
+      });
+      const getRes = await SELF.fetch("http://localhost/api/settings/preferences", { headers });
+      const body = (await getRes.json()) as Record<string, string>;
+      expect(body.miningLoadouts).toBeUndefined();
+    });
+
     it("stores and retrieves stealthPercent", async () => {
       const { sessionToken } = await createTestUser(env.DB);
       const headers = await authHeaders(sessionToken);


### PR DESCRIPTION
Two upgrades to the Rock Calculator (requested after the legibility pass):

## 1. Config in URL params (deep-linkable + shareable)
The full scenario — ship, laser-per-slot, modules-per-slot, gadget, and rock pick — is encoded into the query string via `useSearchParams`, so a link reproduces the exact setup. Encoded by id/uuid (`?ship=1&l0=10&m0-0=50&gadget=90&rock=Iron+(Ore)&el=<uuid>`); decoded back against live `/api/gamedata/mining` data, gracefully dropping ids that drift across a patch. The parent's `tab` param is preserved (functional `setSearchParams`). Hydrate-once-then-sync via a `hydrated` state gate so the writer never clobbers an incoming link with defaults.

## 2. Saved ship loadouts (hybrid persistence)
Save the current ship config (ship + lasers + modules + gadget — **not** the rock) under a name, reload it later. A dropdown of saved loadouts appears once the first one exists, each with delete. **Logged in → saved to your account** (`user_settings` key `miningLoadouts`, a JSON-array string on the existing `/api/settings/preferences` endpoint — no migration, no new endpoint). **Anonymous → localStorage** (`scbridge:mining:loadouts`). The page stays login-free.

## Tests
- Backend: 2 new settings tests (miningLoadouts round-trip + null-clears) — 15/15
- Frontend: `loadoutCodec` (6) + `loadoutStore` (9) pure-logic suites; 328 frontend total
- typecheck + build clean. No migration.

Pure logic is TDD'd; URL/persistence wiring verified via build + staging. Loadouts cap at 20 (oldest dropped).