### PR TITLE
feat(localization): component role/class label field + Type-field UNDEFINED cleanup

### DIFF
--- a/frontend/src/pages/LocalizationBuilder/constants.js
+++ b/frontend/src/pages/LocalizationBuilder/constants.js
@@ -13,7 +13,7 @@ export const LABEL_CATEGORIES = [
 
 // Only fields with meaningful, varied data per category
 export const CATEGORY_FIELDS = {
-  vehicle_components: ['manufacturer', 'size', 'grade', 'subType'],
+  vehicle_components: ['manufacturer', 'size', 'grade', 'subType', 'componentClass'],
   fps_weapons: ['manufacturer', 'size', 'subType'],
   fps_armour: ['manufacturer', 'subType'],
   fps_helmets: ['manufacturer', 'grade', 'subType'],
@@ -29,10 +29,11 @@ export const FIELD_LABELS = {
   grade: 'Grade',
   subType: 'Type',
   seeker: 'Seeker',
+  componentClass: 'Class',
 }
 
 export const EXAMPLE_DATA = {
-  vehicle_components: { name: 'FullStop', manufacturer: 'GODI', size: 2, grade: 'C', subType: 'Cooler' },
+  vehicle_components: { name: 'FullStop', manufacturer: 'GODI', size: 2, grade: 'C', subType: 'Cooler', componentClass: 'Military' },
   fps_weapons: { name: 'Demeco LMG', manufacturer: 'KRIG', size: 2, grade: null, subType: 'LMG' },
   fps_armour: { name: 'Morozov Core', manufacturer: 'AEGS', size: null, grade: null, subType: 'Torso' },
   fps_helmets: { name: 'Calva Helmet', manufacturer: 'AEGS', size: null, grade: 'A', subType: 'Heavy' },
@@ -63,6 +64,7 @@ export function buildPreviewLabel(dbKey, fields, format) {
     if (field === 'grade' && data.grade) parts.push(`Gr.${data.grade}`)
     if (field === 'subType' && data.subType) parts.push(data.subType)
     if (field === 'seeker' && data.seeker) parts.push(data.seeker)
+    if (field === 'componentClass' && data.componentClass) parts.push(data.componentClass)
   }
   const tag = parts.join(' | ')
   if (!tag) return data.name

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -38,6 +38,8 @@ export interface ItemRow {
   seeker?: string | null;
   /** Component role/class (Military/Stealth/Industrial/Civilian/Competition); only set for vehicle_components. */
   componentClass?: string | null;
+  /** Raw component type (vehicle_components.type, e.g. "Cooler"); fallback for the Type field when subType is "UNDEFINED". */
+  type?: string | null;
 }
 
 export type LabelFormat = "suffix" | "prefix";
@@ -172,9 +174,17 @@ function buildDetailTag(
       case "grade":
         if (row.grade) parts.push(`Gr.${row.grade}`);
         break;
-      case "subType":
-        if (row.subType) parts.push(row.subType);
+      case "subType": {
+        // CIG stores SubType="UNDEFINED" for many components (coolers, shields,
+        // quantum drives); the meaningful classification lives in `type`. Use a
+        // real subType, else fall back to the humanized type, else drop it.
+        const typeLabel =
+          row.subType && row.subType !== "UNDEFINED"
+            ? row.subType
+            : humanizeComponentType(row.type ?? null);
+        if (typeLabel) parts.push(typeLabel);
         break;
+      }
       case "seeker":
         if (row.seeker) parts.push(row.seeker);
         break;

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -42,8 +42,22 @@ export interface ItemRow {
 
 export type LabelFormat = "suffix" | "prefix";
 
+/**
+ * Every field that can appear in a label tag. Single source of truth — the
+ * save endpoint's Zod enum (src/routes/localization.ts) is built from this, so
+ * adding a field here automatically keeps validation in sync.
+ */
+export const ALL_LABEL_FIELDS = [
+  "manufacturer",
+  "size",
+  "grade",
+  "subType",
+  "seeker",
+  "componentClass",
+] as const;
+
 /** A field that can appear in a label tag */
-export type LabelField = "manufacturer" | "size" | "grade" | "subType" | "seeker" | "componentClass";
+export type LabelField = (typeof ALL_LABEL_FIELDS)[number];
 
 /** Per-category format configuration */
 export interface CategoryFormat {

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -341,6 +341,9 @@ const COMPONENT_TYPE_LABELS: Record<string, string> = {
 /** Humanize a vehicle_components.type value for display, or null if empty. */
 export function humanizeComponentType(type: string | null): string | null {
   if (!type) return null;
+  // CIG uses the literal "UNDEFINED" as a no-value sentinel on AttachDef
+  // Type/SubType — never a real type. Treat it as null everywhere.
+  if (type.toUpperCase() === "UNDEFINED") return null;
   if (COMPONENT_TYPE_LABELS[type]) return COMPONENT_TYPE_LABELS[type];
   return type
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -36,12 +36,14 @@ export interface ItemRow {
   subType: string | null;
   /** Short missile seeker code (EM/IR/CS); only set for ship_missiles. */
   seeker?: string | null;
+  /** Component role/class (Military/Stealth/Industrial/Civilian/Competition); only set for vehicle_components. */
+  componentClass?: string | null;
 }
 
 export type LabelFormat = "suffix" | "prefix";
 
 /** A field that can appear in a label tag */
-export type LabelField = "manufacturer" | "size" | "grade" | "subType" | "seeker";
+export type LabelField = "manufacturer" | "size" | "grade" | "subType" | "seeker" | "componentClass";
 
 /** Per-category format configuration */
 export interface CategoryFormat {
@@ -60,7 +62,7 @@ export type CategoryFormats = Record<string, CategoryFormat>;
 // Excludes: columns that don't exist on the table, columns where every row
 // has the same value (e.g. grade=A only), or columns with unhelpful data.
 export const CATEGORY_AVAILABLE_FIELDS: Record<string, LabelField[]> = {
-  vehicle_components: ["manufacturer", "size", "grade", "subType"],
+  vehicle_components: ["manufacturer", "size", "grade", "subType", "componentClass"],
   fps_weapons: ["manufacturer", "size", "subType"],
   fps_armour: ["manufacturer", "subType"],
   fps_helmets: ["manufacturer", "grade", "subType"],
@@ -77,6 +79,7 @@ export const FIELD_LABELS: Record<LabelField, string> = {
   grade: "Grade",
   subType: "Type",
   seeker: "Seeker",
+  componentClass: "Class",
 };
 
 /** Default format for a category: all available fields, suffix format */
@@ -160,6 +163,9 @@ function buildDetailTag(
         break;
       case "seeker":
         if (row.seeker) parts.push(row.seeker);
+        break;
+      case "componentClass":
+        if (row.componentClass) parts.push(row.componentClass);
         break;
     }
   }

--- a/src/routes/localization.ts
+++ b/src/routes/localization.ts
@@ -8,6 +8,7 @@ import {
   type ItemRow,
   type LabelOverride,
   type LocalizationConfig,
+  ALL_LABEL_FIELDS,
   DEFAULT_CONFIG,
   configFromRow,
   diffGlobalIni,
@@ -131,7 +132,7 @@ export function localizationRoutes() {
         labelsShipMissiles: z.boolean().optional(),
         labelFormat: z.enum(["suffix", "prefix"]).optional(),
         categoryFormats: z.record(z.string(), z.object({
-          fields: z.array(z.enum(["manufacturer", "size", "grade", "subType", "seeker"])),
+          fields: z.array(z.enum(ALL_LABEL_FIELDS)),
           format: z.enum(["suffix", "prefix"]),
         })).optional(),
         enabledPacks: z.array(z.string().max(100)).max(50).optional(),

--- a/src/routes/localization.ts
+++ b/src/routes/localization.ts
@@ -885,11 +885,13 @@ async function buildOverrides(
     const seekerCol = cat.table === "ship_missiles" ? "t.tracking_signal" : "NULL as tracking_signal";
     // Only vehicle_components carries a component_class (Military/Stealth/…); others select NULL.
     const classCol = cat.table === "vehicle_components" ? "t.component_class" : "NULL as component_class";
+    // Only vehicle_components has a `type` column (fallback when sub_type is "UNDEFINED"); others select NULL.
+    const typeCol = cat.table === "vehicle_components" ? "t.type" : "NULL as type";
 
     const rows = await db
       .prepare(
         `SELECT t.class_name, t.name, m.code as manufacturer_code,
-                ${sizeCol}, ${gradeCol}, t.sub_type, ${seekerCol}, ${classCol}
+                ${sizeCol}, ${gradeCol}, t.sub_type, ${seekerCol}, ${classCol}, ${typeCol}
          FROM ${cat.table} t
          LEFT JOIN manufacturers m ON m.id = t.manufacturer_id
          WHERE t.is_deleted = 0
@@ -904,6 +906,7 @@ async function buildOverrides(
         sub_type: string | null;
         tracking_signal: string | null;
         component_class: string | null;
+        type: string | null;
       }>();
 
     const itemRows: ItemRow[] = rows.results.map((r) => ({
@@ -915,6 +918,7 @@ async function buildOverrides(
       subType: r.sub_type,
       seeker: missileSeekerCode(r.tracking_signal),
       componentClass: r.component_class,
+      type: r.type,
     }));
 
     const catFormat = resolveCategoryFormat(config, cat.table);

--- a/src/routes/localization.ts
+++ b/src/routes/localization.ts
@@ -882,11 +882,13 @@ async function buildOverrides(
     const sizeCol = tablesWithoutSize.includes(cat.table) ? "NULL as size" : "t.size";
     // Only ship_missiles carries a seeker (tracking_signal); others select NULL.
     const seekerCol = cat.table === "ship_missiles" ? "t.tracking_signal" : "NULL as tracking_signal";
+    // Only vehicle_components carries a component_class (Military/Stealth/…); others select NULL.
+    const classCol = cat.table === "vehicle_components" ? "t.component_class" : "NULL as component_class";
 
     const rows = await db
       .prepare(
         `SELECT t.class_name, t.name, m.code as manufacturer_code,
-                ${sizeCol}, ${gradeCol}, t.sub_type, ${seekerCol}
+                ${sizeCol}, ${gradeCol}, t.sub_type, ${seekerCol}, ${classCol}
          FROM ${cat.table} t
          LEFT JOIN manufacturers m ON m.id = t.manufacturer_id
          WHERE t.is_deleted = 0
@@ -900,6 +902,7 @@ async function buildOverrides(
         grade: string | null;
         sub_type: string | null;
         tracking_signal: string | null;
+        component_class: string | null;
       }>();
 
     const itemRows: ItemRow[] = rows.results.map((r) => ({
@@ -910,6 +913,7 @@ async function buildOverrides(
       grade: r.grade,
       subType: r.sub_type,
       seeker: missileSeekerCode(r.tracking_signal),
+      componentClass: r.component_class,
     }));
 
     const catFormat = resolveCategoryFormat(config, cat.table);

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -56,6 +56,11 @@ describe("humanizeComponentType", () => {
     expect(humanizeComponentType("")).toBeNull();
     expect(humanizeComponentType(null)).toBeNull();
   });
+
+  it("treats the CIG 'UNDEFINED' sentinel as null (never a real type)", () => {
+    expect(humanizeComponentType("UNDEFINED")).toBeNull();
+    expect(humanizeComponentType("undefined")).toBeNull();
+  });
 });
 
 describe("missileSeekerCode", () => {
@@ -154,6 +159,14 @@ describe("generateItemLabels — Type field (subType) coalesce vs UNDEFINED", ()
     ];
     const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" });
     expect(out[0].value).toBe("Pint Glass");
+  });
+
+  it("drops the Type field when BOTH subType and type are UNDEFINED (the medical-canister case)", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "Pancea MedGel Canister", size: 1, grade: "1", subType: "UNDEFINED", type: "UNDEFINED" }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["size", "grade", "subType"], format: "suffix" });
+    expect(out[0].value).toBe("Pancea MedGel Canister [S1 | Gr.1]");
   });
 });
 

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -3,6 +3,8 @@ import {
   humanizeComponentType,
   missileSeekerCode,
   generateItemLabels,
+  ALL_LABEL_FIELDS,
+  CATEGORY_AVAILABLE_FIELDS,
   type ItemRow,
 } from "../src/lib/localization";
 
@@ -113,5 +115,24 @@ describe("generateItemLabels — componentClass field", () => {
       format: "suffix",
     });
     expect(out[0].value).toBe("FullStop [Cooler]");
+  });
+});
+
+describe("label-field source of truth", () => {
+  // The save endpoint's Zod enum is built from ALL_LABEL_FIELDS, so it must
+  // contain every field any category can offer — otherwise saving a config
+  // that uses that field fails validation (regression: componentClass was
+  // selectable in the UI but rejected on save).
+  it("ALL_LABEL_FIELDS covers every field in CATEGORY_AVAILABLE_FIELDS", () => {
+    const allowed = new Set<string>(ALL_LABEL_FIELDS);
+    for (const [cat, fields] of Object.entries(CATEGORY_AVAILABLE_FIELDS)) {
+      for (const f of fields) {
+        expect(allowed.has(f), `${cat} offers "${f}" but it's not in ALL_LABEL_FIELDS`).toBe(true);
+      }
+    }
+  });
+
+  it("includes componentClass", () => {
+    expect(ALL_LABEL_FIELDS).toContain("componentClass");
   });
 });

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -29,6 +29,7 @@ function itemRow(over: Partial<ItemRow>): ItemRow {
     subType: null,
     seeker: null,
     componentClass: null,
+    type: null,
     ...over,
   };
 }
@@ -115,6 +116,44 @@ describe("generateItemLabels — componentClass field", () => {
       format: "suffix",
     });
     expect(out[0].value).toBe("FullStop [Cooler]");
+  });
+});
+
+describe("generateItemLabels — Type field (subType) coalesce vs UNDEFINED", () => {
+  // CIG sets AttachDef.SubType="UNDEFINED" for coolers/shields/quantum drives,
+  // putting the real classification in AttachDef.Type ("Cooler"). The Type label
+  // field should fall back to the humanized `type` column rather than print
+  // the literal "UNDEFINED".
+  it("falls back to humanized type when subType is UNDEFINED", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "AbsoluteZero", subType: "UNDEFINED", type: "Cooler" }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" });
+    expect(out[0].value).toBe("AbsoluteZero [Cooler]");
+  });
+
+  it("humanizes a PascalCase type fallback (QuantumDrive -> Quantum Drive)", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "VK00", subType: "UNDEFINED", type: "QuantumDrive" }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" });
+    expect(out[0].value).toBe("VK00 [Quantum Drive]");
+  });
+
+  it("keeps a meaningful subType instead of the type fallback", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "Thruster_X", subType: "FixedThruster", type: "MainThruster" }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" });
+    expect(out[0].value).toBe("Thruster_X [FixedThruster]");
+  });
+
+  it("drops the Type field entirely when subType is UNDEFINED and no type is available", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "Pint Glass", subType: "UNDEFINED", type: null }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" });
+    expect(out[0].value).toBe("Pint Glass");
   });
 });
 

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -26,6 +26,7 @@ function itemRow(over: Partial<ItemRow>): ItemRow {
     grade: null,
     subType: null,
     seeker: null,
+    componentClass: null,
     ...over,
   };
 }
@@ -80,5 +81,37 @@ describe("generateItemLabels — seeker field", () => {
     const rows: ItemRow[] = [itemRow({ seeker: null })];
     const out = generateItemLabels(rows, { fields: ["seeker"], format: "prefix" });
     expect(out[0].value).toBe("Dominator II Missile");
+  });
+});
+
+describe("generateItemLabels — componentClass field", () => {
+  it("appends the component class (Military/Stealth/…) to the tag", () => {
+    const rows: ItemRow[] = [
+      itemRow({
+        className: "cooler_godi_s2_military",
+        name: "FullStop",
+        manufacturerCode: "GODI",
+        size: 2,
+        grade: "C",
+        subType: "Cooler",
+        componentClass: "Military",
+      }),
+    ];
+    const out = generateItemLabels(rows, {
+      fields: ["manufacturer", "size", "grade", "subType", "componentClass"],
+      format: "suffix",
+    });
+    expect(out[0].value).toBe("FullStop [GODI | S2 | Gr.C | Cooler | Military]");
+  });
+
+  it("omits the class when the row has none", () => {
+    const rows: ItemRow[] = [
+      itemRow({ name: "FullStop", subType: "Cooler", componentClass: null }),
+    ];
+    const out = generateItemLabels(rows, {
+      fields: ["subType", "componentClass"],
+      format: "suffix",
+    });
+    expect(out[0].value).toBe("FullStop [Cooler]");
   });
 });


### PR DESCRIPTION
## Component role/class label field for the Localization Builder

Resolves #165. Adds an opt-in **Class** label field so vehicle-component names can show their role (Civilian / Military / Industrial / Stealth / Competition) alongside size, grade, and type — e.g. `Cooler [GODI | S2 | Gr.C | Cooler | Military]`.

The role already exists in `vehicle_components.component_class` (migration 0163, extracted from the in-game "Class: X" description line) — this just surfaces it. No DB migration. Opt-in: only renders if the user adds "Class" to their vehicle-components label format, so existing labels are unchanged. Verified non-inert against 4.8 p4k (475 components carry a Class across all five roles).

### Commits
- **feat** — `componentClass` label field wired through lib, the download route query, and the frontend field config + preview.
- **fix (save)** — the save endpoint's `categoryFormats` validator hardcoded its field enum separately from the `LabelField` type, so picking "Class" failed with *"Save failed: Invalid option"*. Made `ALL_LABEL_FIELDS` the single source of truth (type + `z.enum` derived from it) so they can't drift; added an invariant test.
- **fix (Type field UNDEFINED)** — CIG stores `AttachDef.SubType = "UNDEFINED"` for coolers/shields/quantum drives (verified in p4k), which the Type field printed literally. The Type field now coalesces to the humanized `type` column (the source the blueprint "(Type)" annotation already uses); a literal `UNDEFINED` is dropped everywhere.
- **fix (UNDEFINED sentinel)** — 1,160 components have `type` = `"UNDEFINED"` too; `humanizeComponentType` now treats the `"UNDEFINED"` sentinel as null, hardening the blueprint annotation as well.

### Testing
- Backend: 645 pass / 1 skip (18 localization-label tests incl. new invariant + coalesce + sentinel cases)
- Verified end-to-end through an exported `global.ini` on staging: Class shows on 106 component labels (all 5 roles); zero `UNDEFINED` remaining.

Closes #165
