### PR TITLE
fix(missions): faction detail panel no longer clips tall blueprint lists

### DIFF
--- a/frontend/src/pages/FactionDetail.jsx
+++ b/frontend/src/pages/FactionDetail.jsx
@@ -685,11 +685,14 @@ export default function FactionDetail() {
         )}
       </div>
 
-      {/* Slide container */}
-      <div className="relative overflow-hidden min-h-[200px]">
+      {/* Slide container — both panels share one grid cell so the container
+          sizes to whichever is taller. (Absolute-positioning the detail panel
+          removed it from flow, so a tall blueprint list overflowed the
+          list-height container and got clipped — #147 / #163.) */}
+      <div className="relative grid overflow-hidden min-h-[200px]">
         {/* Mission list */}
         <div
-          className={`transition-all duration-500 ease-in-out ${isDetailView ? 'pointer-events-none' : ''}`}
+          className={`col-start-1 row-start-1 transition-all duration-500 ease-in-out ${isDetailView ? 'pointer-events-none' : ''}`}
           style={{ transform: isDetailView ? 'translateX(-100%)' : 'translateX(0)', opacity: isDetailView ? 0 : 1 }}
         >
           {/* Category filter */}
@@ -750,7 +753,7 @@ export default function FactionDetail() {
 
         {/* Mission detail (slides in from right) */}
         <div
-          className={`absolute top-0 left-0 right-0 transition-all duration-500 ease-in-out ${!isDetailView ? 'pointer-events-none' : ''}`}
+          className={`col-start-1 row-start-1 transition-all duration-500 ease-in-out ${!isDetailView ? 'pointer-events-none' : ''}`}
           style={{ transform: isDetailView ? 'translateX(0)' : 'translateX(100%)', opacity: isDetailView ? 1 : 0 }}
         >
           {selectedMission && (


### PR DESCRIPTION
## Fix faction detail panel clipping tall blueprint lists

Resolves #147 and #163.

On the missions/faction page, the list→detail slide container used `overflow-hidden` with the **detail panel absolutely positioned**, so the container's height was driven by the mission *list*, not the detail panel. When a generator's blueprint-rewards list was taller than the list (e.g. `vaughn_generator` has **43 blueprints**), it overflowed and was clipped with no scroll — "cut off at bottom, ~20 of 43 showing" (#147) / "only the top half renders" (#163).

### Fix
Stack both panels in one CSS grid cell (`col-start-1 row-start-1`) instead of absolute-positioning the detail panel. The grid sizes to whichever panel is taller, so the full blueprint list renders. The horizontal slide animation is preserved.

### Verification
- Confirmed the API returns all 43 blueprints (not a data cap)
- Frontend build + 328 tests pass
- Browser-verified on staging (`/missions/faction/vaughn?mission=gen-vaughn_generator`): all 43 blueprint links render; grid container `scrollHeight == clientHeight`, `clipped: false`

Closes #147
Closes #163
