### PR TITLE
feat(loot): community price reporting — Where to Buy + user reports

### DIFF
--- a/frontend/src/hooks/useAPI.js
+++ b/frontend/src/hooks/useAPI.js
@@ -379,6 +379,17 @@ export function useLootItem(uuid) {
   return useAPI(uuid ? `/loot/${uuid}` : null, { skip: !uuid })
 }
 
+// Player-visitable shop list (id, name, display_name, location_label) for the
+// price-report picker.
+export function useShopList() {
+  return useAPI('/gamedata/shops')
+}
+
+// Submit a community price report for an item at a shop (requires auth).
+export async function reportItemPrice(uuid, { shopId, buyPrice, sellPrice }) {
+  return apiFetch('POST', `/loot/${uuid}/report-price`, { shopId, buyPrice, sellPrice })
+}
+
 export function useLootLocations() {
   return useAPI('/loot/locations')
 }

--- a/frontend/src/pages/LootDB/FullItemDetail.jsx
+++ b/frontend/src/pages/LootDB/FullItemDetail.jsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
-import { ArrowLeft, ShoppingCart, Package, Swords, FileText, Bookmark, BookmarkPlus, Plus, Check } from 'lucide-react'
+import { ArrowLeft, Package, Swords, FileText, Bookmark, BookmarkPlus, Plus, Check, MapPin } from 'lucide-react'
 import { useLootItem, useLootCollection, useLootWishlist, toggleLootWishlist, setLootCollectionQuantity } from '../../hooks/useAPI'
 import { useSession } from '../../lib/auth-client'
 import { rarityStyle, CATEGORY_BADGE_STYLES, CATEGORY_LABELS, effectiveCategory, humanizeRawDisplayName } from '../../lib/lootDisplay'
@@ -8,6 +9,54 @@ import LoadingState from '../../components/LoadingState'
 import ErrorState from '../../components/ErrorState'
 import ResistanceBar from './ResistanceBar'
 import LocationSection from './LocationSection'
+import ReportPriceModal from './ReportPriceModal'
+
+// Price provenance → display label + badge style (#139: UEX / SC-Companion / User Reported)
+const PRICE_SOURCE_BADGES = {
+  uex: { label: 'UEX', cls: 'bg-sky-500/10 text-sky-400 border-sky-500/20' },
+  'sc-companion': { label: 'SC-Companion', cls: 'bg-violet-500/10 text-violet-400 border-violet-500/20' },
+  user: { label: 'User Reported', cls: 'bg-amber-500/10 text-amber-400 border-amber-500/20' },
+}
+
+function WhereToBuy({ shops, isAuthed, onReport }) {
+  const sorted = [...shops].sort((a, b) => (a.location_label || '').localeCompare(b.location_label || ''))
+  return (
+    <div className="panel p-4">
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <h3 className="text-[10px] font-display uppercase tracking-widest text-gray-500">Where to Buy</h3>
+        {isAuthed ? (
+          <button onClick={onReport} className="text-[10px] font-mono text-sc-accent hover:text-sc-accent/80 transition-colors">+ Report price</button>
+        ) : (
+          <Link to="/login" className="text-[10px] font-mono text-gray-500 hover:text-gray-300 transition-colors">Log in to report</Link>
+        )}
+      </div>
+      {sorted.length === 0 ? (
+        <div className="flex items-center gap-2 px-3 py-4 text-xs text-gray-500">
+          <MapPin className="w-3.5 h-3.5 text-gray-600" />
+          Location unknown — no community price reported yet.
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {sorted.map((s, i) => {
+            const badge = PRICE_SOURCE_BADGES[s.price_source] || null
+            return (
+              <div key={i} className="flex items-center justify-between gap-2 pl-2 border-l border-sc-border py-0.5">
+                <span className="min-w-0">
+                  <span className="text-xs font-mono text-gray-200 break-words">{s.shop_name}</span>
+                  {s.location_label && <span className="text-[10px] font-mono text-gray-500 ml-1.5">{s.location_label}</span>}
+                </span>
+                <span className="flex items-center gap-1.5 shrink-0">
+                  {s.buy_price > 0 && <span className="text-[11px] font-mono text-amber-400">{Math.round(s.buy_price).toLocaleString()} aUEC</span>}
+                  {badge && <span className={`text-[9px] font-mono px-1 py-0.5 rounded border ${badge.cls}`}>{badge.label}</span>}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
 
 const STAT_GROUPS = {
   combat: {
@@ -106,9 +155,10 @@ function StatGroup({ label, stats, det }) {
 export default function FullItemDetail() {
   const { uuid } = useParams()
   const navigate = useNavigate()
-  const { data: item, loading, error } = useLootItem(uuid)
+  const { data: item, loading, error, refetch } = useLootItem(uuid)
   const { data: session } = useSession()
   const isAuthed = !!session?.user
+  const [reportOpen, setReportOpen] = useState(false)
   const { data: collectionIds, refetch: refetchCollection } = useLootCollection(isAuthed)
   const { data: wishlistItems, refetch: refetchWishlist } = useLootWishlist(isAuthed)
 
@@ -214,10 +264,12 @@ export default function FullItemDetail() {
         ))}
       </div>
 
-      {/* Where to find */}
+      {/* Where to buy — shops + prices (UEX / SC-Companion / user reports) */}
+      <WhereToBuy shops={locationData('shops')} isAuthed={isAuthed} onReport={() => setReportOpen(true)} />
+
+      {/* Where to find — containers, NPCs, contracts (shops moved to Where to Buy) */}
       {(() => {
         const locationSections = [
-          { label: 'Shops', icon: ShoppingCart, type: 'shops', data: locationData('shops') },
           { label: 'Containers', icon: Package, type: 'containers', data: locationData('containers'), npcData: npcEntries },
           { label: 'Contracts', icon: FileText, type: 'contracts', data: locationData('contracts') },
         ]
@@ -234,6 +286,15 @@ export default function FullItemDetail() {
           </div>
         )
       })()}
+
+      {reportOpen && (
+        <ReportPriceModal
+          uuid={uuid}
+          itemName={humanizeRawDisplayName(item.name)}
+          onClose={() => setReportOpen(false)}
+          onSubmitted={refetch}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/LootDB/ReportPriceModal.jsx
+++ b/frontend/src/pages/LootDB/ReportPriceModal.jsx
@@ -1,0 +1,153 @@
+import { useState, useMemo } from 'react'
+import { X, Search, Loader, Store } from 'lucide-react'
+import { useShopList, reportItemPrice } from '../../hooks/useAPI'
+
+/**
+ * Modal for submitting a community price report (#139). The user picks a shop
+ * and enters a buy and/or sell price; it's saved as source='user' and surfaces
+ * alongside UEX / SC-Companion data.
+ */
+export default function ReportPriceModal({ uuid, itemName, onClose, onSubmitted }) {
+  const { data: shops, loading: shopsLoading } = useShopList()
+  const [query, setQuery] = useState('')
+  const [shopId, setShopId] = useState(null)
+  const [buyPrice, setBuyPrice] = useState('')
+  const [sellPrice, setSellPrice] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  const selectedShop = useMemo(
+    () => (shops || []).find(s => s.id === shopId) || null,
+    [shops, shopId]
+  )
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    return (shops || [])
+      .filter(s => {
+        const name = (s.display_name || s.name || '').toLowerCase()
+        const loc = (s.location_label || '').toLowerCase()
+        return name.includes(q) || loc.includes(q)
+      })
+      .slice(0, 25)
+  }, [shops, query])
+
+  const canSubmit = shopId != null && (buyPrice !== '' || sellPrice !== '') && !saving
+
+  const handleSubmit = async () => {
+    setError(null)
+    setSaving(true)
+    try {
+      await reportItemPrice(uuid, {
+        shopId,
+        buyPrice: buyPrice === '' ? null : Number(buyPrice),
+        sellPrice: sellPrice === '' ? null : Number(sellPrice),
+      })
+      onSubmitted?.()
+      onClose()
+    } catch (e) {
+      setError(e.message || 'Failed to submit report')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="w-full max-w-md panel p-5 space-y-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-display font-bold text-white">Report price & location</h3>
+            <p className="text-[11px] text-gray-500 mt-0.5 break-words">{itemName}</p>
+          </div>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-300 transition-colors" aria-label="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Shop picker */}
+        <div className="space-y-1.5">
+          <label className="text-[10px] font-display uppercase tracking-wider text-gray-500">Shop</label>
+          {selectedShop ? (
+            <div className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-sc-accent/5 border border-sc-accent/20">
+              <span className="flex items-center gap-2 text-xs text-gray-200 min-w-0">
+                <Store className="w-3.5 h-3.5 text-sc-accent shrink-0" />
+                <span className="truncate">{selectedShop.display_name || selectedShop.name}</span>
+                {selectedShop.location_label && (
+                  <span className="text-[10px] text-gray-500 shrink-0">— {selectedShop.location_label}</span>
+                )}
+              </span>
+              <button onClick={() => { setShopId(null); setQuery('') }} className="text-[10px] text-gray-500 hover:text-gray-300 shrink-0">change</button>
+            </div>
+          ) : (
+            <div className="relative">
+              <Search className="w-3.5 h-3.5 text-gray-600 absolute left-3 top-1/2 -translate-y-1/2" />
+              <input
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder={shopsLoading ? 'Loading shops…' : 'Search shops by name or location…'}
+                disabled={shopsLoading}
+                className="w-full pl-9 pr-3 py-2 rounded-lg bg-black/30 border border-sc-border text-xs text-gray-200 placeholder-gray-600 focus:border-sc-accent/40 focus:outline-none"
+              />
+              {matches.length > 0 && (
+                <div className="absolute z-10 mt-1 w-full max-h-56 overflow-y-auto rounded-lg bg-[#0d1117] border border-sc-border shadow-xl">
+                  {matches.map(s => (
+                    <button
+                      key={s.id}
+                      onClick={() => { setShopId(s.id); setQuery('') }}
+                      className="flex items-center justify-between gap-2 w-full text-left px-3 py-2 hover:bg-white/[0.04] transition-colors"
+                    >
+                      <span className="text-xs text-gray-200 truncate">{s.display_name || s.name}</span>
+                      {s.location_label && <span className="text-[10px] text-gray-500 shrink-0">{s.location_label}</span>}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Prices */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <label className="text-[10px] font-display uppercase tracking-wider text-gray-500">Buy price (aUEC)</label>
+            <input
+              type="number" min="0" inputMode="numeric"
+              value={buyPrice}
+              onChange={e => setBuyPrice(e.target.value)}
+              placeholder="—"
+              className="w-full px-3 py-2 rounded-lg bg-black/30 border border-sc-border text-xs text-gray-200 placeholder-gray-600 focus:border-sc-accent/40 focus:outline-none"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-[10px] font-display uppercase tracking-wider text-gray-500">Sell price (aUEC)</label>
+            <input
+              type="number" min="0" inputMode="numeric"
+              value={sellPrice}
+              onChange={e => setSellPrice(e.target.value)}
+              placeholder="—"
+              className="w-full px-3 py-2 rounded-lg bg-black/30 border border-sc-border text-xs text-gray-200 placeholder-gray-600 focus:border-sc-accent/40 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-[11px] text-red-400">{error}</p>}
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button onClick={onClose} className="px-3 py-1.5 rounded-lg text-xs text-gray-400 hover:text-gray-200 transition-colors">Cancel</button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-sc-accent/15 text-sc-accent border border-sc-accent/30 hover:bg-sc-accent/25 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+          >
+            {saving && <Loader className="w-3.5 h-3.5 animate-spin" />}
+            Submit report
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1185,6 +1185,72 @@ export async function getLootItems(db: D1Database, isPTU = false): Promise<LootI
   return result.results as unknown as LootItem[];
 }
 
+/**
+ * Record a user-reported price for an item at a shop. Mirrors the UEX/companion
+ * write path: appends an append-only row to price_observations (source='user')
+ * and upserts terminal_inventory.latest_* with latest_source='user', so the
+ * report surfaces through the same shop-availability query as UEX. The user
+ * picks a shop (how players think); we attach to that shop's first terminal —
+ * display is by shop, so the exact terminal is immaterial.
+ */
+export async function reportUserItemPrice(
+  db: D1Database,
+  uuid: string,
+  shopId: number,
+  buyPrice: number | null,
+  sellPrice: number | null,
+  userId: string,
+  isPTU = false,
+): Promise<{ ok: true } | { error: string; status: 400 | 404 }> {
+  const t = (name: string) => (isPTU ? `ptu_${name}` : name);
+
+  const item = await db
+    .prepare(`SELECT name FROM ${t("loot_map")} WHERE uuid = ? AND is_deleted = 0`)
+    .bind(uuid)
+    .first<{ name: string }>();
+  if (!item) return { error: "Item not found", status: 404 };
+
+  const term = await db
+    .prepare(`SELECT id FROM ${t("terminals")} WHERE shop_id = ? AND is_deleted = 0 ORDER BY id LIMIT 1`)
+    .bind(shopId)
+    .first<{ id: number }>();
+  if (!term) return { error: "That shop has no terminal to attach a price to", status: 400 };
+
+  const gv = await db
+    .prepare(`SELECT id FROM game_versions WHERE channel = 'LIVE' AND is_default = 1 LIMIT 1`)
+    .first<{ id: number }>();
+  const gvId = gv?.id ?? null;
+
+  const stmts: D1PreparedStatement[] = [];
+  const obs = (type: "buy" | "sell", price: number) =>
+    db
+      .prepare(
+        `INSERT INTO ${t("price_observations")} (terminal_id, item_uuid, observation_type, price, source, user_id, observed_at)
+         VALUES (?, ?, ?, ?, 'user', ?, datetime('now'))`,
+      )
+      .bind(term.id, uuid, type, price, userId);
+  if (buyPrice != null) stmts.push(obs("buy", buyPrice));
+  if (sellPrice != null) stmts.push(obs("sell", sellPrice));
+
+  stmts.push(
+    db
+      .prepare(
+        `INSERT INTO ${t("terminal_inventory")}
+          (terminal_id, item_uuid, item_type, item_name, latest_buy_price, latest_sell_price, latest_source, latest_observed_at, game_version_id)
+         VALUES (?, ?, 'item', ?, ?, ?, 'user', datetime('now'), ?)
+         ON CONFLICT(terminal_id, item_uuid) DO UPDATE SET
+           latest_buy_price = COALESCE(excluded.latest_buy_price, terminal_inventory.latest_buy_price),
+           latest_sell_price = COALESCE(excluded.latest_sell_price, terminal_inventory.latest_sell_price),
+           latest_source = 'user',
+           latest_observed_at = datetime('now')`,
+      )
+      .bind(term.id, uuid, item.name, buyPrice, sellPrice, gvId),
+  );
+
+  await db.batch(stmts);
+  return { ok: true };
+}
+
 export async function getLootByUuid(db: D1Database, uuid: string, isPTU = false): Promise<Record<string, unknown> | null> {
   // Channel-aware table aliases. Every versioned table this function references
   // routes through `t(...)`; non-versioned tables (npc_factions, user_*, etc.)
@@ -1426,6 +1492,7 @@ export async function getLootByUuid(db: D1Database, uuid: string, isPTU = false)
   const shopAvailability = await db.prepare(`
     SELECT ti.latest_buy_price AS buy_price,
            ti.latest_sell_price AS sell_price,
+           ti.latest_source AS price_source,
            ti.uex_date_modified AS uex_date_modified,
            s.name AS shop_name, s.slug AS shop_slug,
            s.location_label, s.display_name
@@ -1451,6 +1518,7 @@ export async function getLootByUuid(db: D1Database, uuid: string, isPTU = false)
       location_label: r.location_label,
       buy_price: r.buy_price,
       sell_price: r.sell_price,
+      price_source: r.price_source,
       uex_date_modified: r.uex_date_modified,
     });
   }

--- a/src/routes/loot.ts
+++ b/src/routes/loot.ts
@@ -18,9 +18,10 @@ import {
   removeFromLootWishlist,
   getLootSets,
   getLootSetBySlug,
+  reportUserItemPrice,
 } from "../db/queries";
 import { validate } from "../lib/validation";
-import { cachedJson, cacheSlug } from "../lib/cache";
+import { cachedJson, cacheSlug, purgeByPrefix } from "../lib/cache";
 import { getActiveChannel, isPTUChannel } from "../lib/ptu";
 
 // Auth middleware — reused for collection and wishlist sub-paths
@@ -256,6 +257,50 @@ export function lootRoutes() {
       },
     );
   });
+
+  // POST /api/loot/:uuid/report-price — community price report (auth required).
+  // Stored like UEX/companion data: source='user' in the same tables, so it
+  // surfaces through the standard shop-availability query.
+  app.post(
+    "/:uuid/report-price",
+    requireUser,
+    validate(
+      "json",
+      z
+        .object({
+          shopId: z.number().int().positive(),
+          buyPrice: z.number().nonnegative().max(1_000_000_000).nullable().optional(),
+          sellPrice: z.number().nonnegative().max(1_000_000_000).nullable().optional(),
+        })
+        .refine((b) => b.buyPrice != null || b.sellPrice != null, {
+          message: "Provide a buy and/or sell price",
+        }),
+    ),
+    async (c) => {
+      const uuid = c.req.param("uuid");
+      const { shopId, buyPrice, sellPrice } = c.req.valid("json");
+      const userId = getAuthUser(c).id;
+      const channel = getActiveChannel(c);
+      const isPTU = isPTUChannel(channel);
+      const result = await reportUserItemPrice(
+        c.env.DB,
+        uuid,
+        shopId,
+        buyPrice ?? null,
+        sellPrice ?? null,
+        userId,
+        isPTU,
+      );
+      if ("error" in result) return c.json({ error: result.error }, result.status);
+      // Purge the cached detail so the new price surfaces immediately.
+      c.executionCtx.waitUntil(
+        purgeByPrefix(c.env.SC_BRIDGE_CACHE, `loot:detail:${cacheSlug(uuid)}`).catch((err) =>
+          console.error("report-price cache purge failed", err),
+        ),
+      );
+      return c.json({ ok: true });
+    },
+  );
 
   // GET /api/loot/:uuid — full detail + location data (public)
   // Must be last to avoid matching /collection and /wishlist

--- a/test/loot-price-report.test.ts
+++ b/test/loot-price-report.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { setupTestDatabase, TEST_GAME_VERSION_ID } from "./apply-migrations";
+import { createTestUser, authHeaders, seedLootItem } from "./helpers";
+
+/**
+ * POST /api/loot/:uuid/report-price — community price reporting (#139).
+ * A logged-in user reports a price for an item at a shop; it's stored like
+ * UEX/companion data (source='user' in the same tables) and then surfaces
+ * through the standard shop-availability query with price_source='user'.
+ */
+describe("POST /api/loot/:uuid/report-price", () => {
+  beforeAll(async () => {
+    await setupTestDatabase(env.DB);
+  });
+
+  async function seedShopWithTerminal(name: string): Promise<number> {
+    const slug = `${name.toLowerCase().replace(/\s+/g, "-")}-${crypto.randomUUID().slice(0, 6)}`;
+    await env.DB.prepare(
+      `INSERT INTO shops (uuid, name, slug, location_label, game_version_id) VALUES (?, ?, ?, ?, ?)`,
+    )
+      .bind(crypto.randomUUID(), name, slug, `${name} (Test Location)`, TEST_GAME_VERSION_ID)
+      .run();
+    const shop = await env.DB.prepare("SELECT id FROM shops WHERE slug = ?").bind(slug).first<{ id: number }>();
+    await env.DB.prepare(
+      `INSERT INTO terminals (uuid, shop_id, shop_name_key, terminal_type, game_version_id) VALUES (?, ?, ?, 'item', ?)`,
+    )
+      .bind(crypto.randomUUID(), shop!.id, slug, TEST_GAME_VERSION_ID)
+      .run();
+    return shop!.id;
+  }
+
+  it("rejects unauthenticated reports with 401", async () => {
+    const { uuid } = await seedLootItem(env.DB, { name: "ReportAuthGun" });
+    const res = await SELF.fetch(`http://localhost/api/loot/${uuid}/report-price`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ shopId: 1, buyPrice: 100 }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a report with neither a buy nor sell price", async () => {
+    const { uuid } = await seedLootItem(env.DB, { name: "ReportEmptyGun" });
+    const shopId = await seedShopWithTerminal("Empty Bay");
+    const { sessionToken } = await createTestUser(env.DB);
+    const res = await SELF.fetch(`http://localhost/api/loot/${uuid}/report-price`, {
+      method: "POST",
+      headers: { ...(await authHeaders(sessionToken)), "Content-Type": "application/json" },
+      body: JSON.stringify({ shopId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("saves a user price that then surfaces as a shop with price_source 'user'", async () => {
+    const { uuid } = await seedLootItem(env.DB, { name: "ReportableGun" });
+    const shopId = await seedShopWithTerminal("Platinum Bay");
+    const { sessionToken } = await createTestUser(env.DB);
+
+    const res = await SELF.fetch(`http://localhost/api/loot/${uuid}/report-price`, {
+      method: "POST",
+      headers: { ...(await authHeaders(sessionToken)), "Content-Type": "application/json" },
+      body: JSON.stringify({ shopId, buyPrice: 16740 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    const detail = (await (await SELF.fetch(`http://localhost/api/loot/${uuid}`)).json()) as {
+      locations: { shops: Array<{ buy_price: number; price_source: string; shop_name: string }> };
+    };
+    const reported = detail.locations.shops.find((s) => s.buy_price === 16740);
+    expect(reported).toBeDefined();
+    expect(reported!.price_source).toBe("user");
+    expect(reported!.shop_name).toBe("Platinum Bay");
+  });
+
+  it("returns 404 for an unknown item uuid", async () => {
+    const shopId = await seedShopWithTerminal("Ghost Bay");
+    const { sessionToken } = await createTestUser(env.DB);
+    const res = await SELF.fetch(`http://localhost/api/loot/00000000-0000-0000-0000-000000000000/report-price`, {
+      method: "POST",
+      headers: { ...(await authHeaders(sessionToken)), "Content-Type": "application/json" },
+      body: JSON.stringify({ shopId, buyPrice: 100 }),
+    });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Community price reporting — "Where to Buy" + user reports

Resolves #139.

The item detail page only surfaced shops that had a community-reported (UEX) price; items without one showed an empty/hidden shop section (e.g. the reporter's Attrition-4). Per the design direction, we don't trust unreliable game-file base prices — instead we rely on UEX + our own data, and when a location is unknown we say so and let signed-in users report it.

### Backend (`ec7bf050`)
- `POST /api/loot/:uuid/report-price` (auth, Zod `{shopId, buyPrice?, sellPrice?}`) → appends to `price_observations` (`source='user'`) and upserts `terminal_inventory.latest_*` (`latest_source='user'`), mirroring the UEX/SC-Companion write path exactly — one table, three sources distinguished by `source`.
- Shop query now returns `price_source` for provenance badging.
- No migration (tables already carry `source` + `user_id`).

### Frontend (`4d9eaffe`)
- New **"Where to Buy"** section (split out of "Where to Find"): shops with prices + a provenance badge (UEX / SC-Companion / User Reported).
- Empty → **"Location unknown — no community price reported yet"** instead of a hidden section.
- **"+ Report price"** (logged-in) → modal with a searchable shop picker + buy/sell fields; logged-out → "Log in to report".

### Testing
- 650 backend (4 new: auth gate, validation, 404, round-trip surfacing `price_source: 'user'`) + 328 frontend, all pass.
- Browser-verified on staging: populated state shows shops + prices + UEX badges; empty state shows "Location unknown" + report affordance.

Closes #139
