### PR TITLE
fix(crafting): clear How-to-Obtain states for sourceless blueprints

### DIFF
--- a/frontend/src/pages/Crafting/BlueprintDetail.jsx
+++ b/frontend/src/pages/Crafting/BlueprintDetail.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
-import { ArrowLeft, Clock, Layers, FlaskConical, Crosshair, Zap, Target, MapPin, Gift, FileText } from 'lucide-react'
+import { ArrowLeft, Clock, Layers, FlaskConical, Crosshair, Zap, Target, MapPin, Gift, FileText, Lock } from 'lucide-react'
 import { useCrafting } from '../../hooks/useAPI'
 import LoadingState from '../../components/LoadingState'
 import ErrorState from '../../components/ErrorState'
@@ -258,10 +258,15 @@ export default function BlueprintDetail() {
                 </Link>
               ))}
             </div>
-          ) : (
-            <p className="text-xs text-gray-500 italic">
-              Blueprint acquisition unknown — may be available at fabricators or from missions not yet documented.
+          ) : blueprint.is_default ? (
+            <p className="text-xs text-emerald-400/80 italic">
+              Known by default — available to craft from the start, no blueprint needed.
             </p>
+          ) : (
+            <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs bg-amber-500/5 border border-amber-500/15 text-amber-400/90">
+              <Lock className="w-3 h-3" />
+              <span>Exists in-game, but not yet obtainable — Star Citizen defines no source for this blueprint yet.</span>
+            </div>
           )}
         </div>
       </div>

--- a/src/routes/gamedata.ts
+++ b/src/routes/gamedata.ts
@@ -970,9 +970,9 @@ return cachedJson(c, `gd:missions`, async () => {
     const db = c.env.DB
 return cachedJson(c, `gd:crafting`, async () => {
       const [bpResult, slotResult, modResult, propResult, resResult] = await Promise.all([
-        db.prepare(`SELECT cb.id, cb.uuid, cb.tag, cb.name, cb.type, cb.sub_type, cb.craft_time_seconds
+        db.prepare(`SELECT cb.id, cb.uuid, cb.tag, cb.name, cb.type, cb.sub_type, cb.craft_time_seconds, cb.is_default
            FROM ${t("crafting_blueprints")} cb
-           
+
            ORDER BY cb.type, cb.sub_type, cb.name`
         ).all(),
         db.prepare(`SELECT MIN(cbs.id) AS id, cbs.crafting_blueprint_id, cbs.slot_index, COALESCE(cbs.slot_name, cbs.name) AS name,


### PR DESCRIPTION
## Clear "How to Obtain" states for blueprints with no source

Resolves #141.

Many crafting blueprints (e.g. ORC-mkX armor) exist in-game but CIG defines no way to obtain them yet. Verified against 4.8 p4k: the ORC-mkX Legs Autumn blueprint record (`658c2852…`) is referenced by no reward pool / contract / vendor anywhere in DataCore, `is_default=0`, and `unlockRequirements` is `null`. (~17 of 29 cds_armor blueprints are in this state.) The old fallback — "may be available at fabricators or from missions not yet documented" — implied a source that doesn't exist.

### Change
"How to Obtain" now has three states:
- **Has sources** → list the missions/contracts (unchanged)
- **`is_default`** → "Known by default — available to craft from the start"
- **Otherwise** → "Exists in-game, but not yet obtainable — Star Citizen defines no source for this blueprint yet"

Exposes `crafting_blueprints.is_default` on `GET /api/gamedata/crafting` to drive the distinction.

### Testing
- typecheck + 328 frontend tests + backend suite pass
- Browser-verified on staging: ORC-mkX Legs Autumn shows the "not yet obtainable" state; `gd:crafting` payload confirmed to include `is_default`.

Closes #141
