### PR TITLE
feat(uex): durably backfill loot_map for buy-only items (#135)

### DIFF
--- a/src/lib/uex.ts
+++ b/src/lib/uex.ts
@@ -60,7 +60,54 @@ async function fetchUex<T>(endpoint: string): Promise<T[]> {
 export interface SyncResult {
   commodities: number;
   items: number;
+  /** loot_map rows created for buy-only items that UEX knows but extraction misses. */
+  backfilled?: number;
   errors: string[];
+}
+
+/**
+ * Backfill loot_map for "buy-only" items: items UEX prices but that the p4k
+ * extractor never produced (they're sold at shops but never in a loot table,
+ * so the loot-table-driven loot_map build skips them — e.g. the RediMake
+ * fabricator, ship bombs, refueling nozzles, ship modules, mobiGlas casings).
+ *
+ * Without a loot_map row they're unsearchable and their UEX prices are orphaned.
+ * This creates a minimal loot_map row keyed by the item's uuid (matching
+ * terminal_inventory.item_uuid), so it becomes searchable and the "Where to Buy"
+ * shop query links its prices automatically. Idempotent (NOT EXISTS guard) and
+ * self-healing — re-creates rows after a full DB reload on the next sync.
+ *
+ * Category is assigned by name (the entity isn't extracted, so we have no type).
+ * Tagged data_source='terminal_inventory_backfill'. Excludes UEX commodities
+ * (item_type='commodity' live in trade_commodities) and lowercase/placeholder junk.
+ */
+export async function backfillBuyOnlyLootMap(db: D1Database, gvId: number): Promise<number> {
+  const res = await db
+    .prepare(
+      `INSERT INTO loot_map (uuid, name, category, data_source, game_version_id)
+       SELECT g.item_uuid, g.item_name,
+         CASE WHEN g.item_name LIKE 'mobiGlas%' THEN 'clothing'
+              WHEN g.item_name LIKE '%Bomb%' OR g.item_name LIKE '%Gatling%' THEN 'ship_weapon'
+              WHEN g.item_name LIKE 'RediMake%' THEN 'misc'
+              ELSE 'ship_component' END,
+         'terminal_inventory_backfill', ?1
+       FROM (
+         SELECT DISTINCT ti.item_uuid, ti.item_name
+         FROM terminal_inventory ti
+         WHERE ti.is_deleted = 0
+           AND ti.latest_source IS NOT NULL
+           AND ti.item_type = 'item'
+           AND (ti.latest_buy_price > 0 OR ti.latest_sell_price > 0)
+           AND ti.item_name GLOB '*[A-Z]*'
+           AND ti.item_name NOT LIKE '%PLACEHOLDER%'
+           AND NOT EXISTS (
+             SELECT 1 FROM loot_map lm WHERE lm.uuid = ti.item_uuid AND lm.is_deleted = 0
+           )
+       ) g`,
+    )
+    .bind(gvId)
+    .run();
+  return res.meta?.changes ?? 0;
 }
 
 export async function syncUexPrices(
@@ -99,6 +146,10 @@ export async function syncUexPrices(
   try {
     if (type === "items" || type === "all") {
       result.items = await syncItems(db, uexToOurs, gvId);
+      // Durable fix for buy-only items the p4k extractor misses (#135): once
+      // UEX knows an item, ensure it has a loot_map row so it's searchable +
+      // price-linked. Self-healing across full DB reloads.
+      result.backfilled = await backfillBuyOnlyLootMap(db, gvId);
     }
   } catch (e) {
     result.errors.push(`Item sync failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/test/uex-backfill.test.ts
+++ b/test/uex-backfill.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { env } from "cloudflare:test";
+import { setupTestDatabase, TEST_GAME_VERSION_ID } from "./apply-migrations";
+import { backfillBuyOnlyLootMap } from "../src/lib/uex";
+
+/**
+ * backfillBuyOnlyLootMap (#135 durable fix) — once UEX prices an item that the
+ * p4k extractor missed (buy-only, never in a loot table), ensure it gets a
+ * loot_map row so it's searchable + price-linked. Runs on every UEX item sync;
+ * idempotent; self-heals across full DB reloads.
+ */
+describe("backfillBuyOnlyLootMap", () => {
+  beforeAll(async () => {
+    await setupTestDatabase(env.DB);
+  });
+
+  async function seedUexItem(uuid: string, name: string): Promise<void> {
+    // shop + terminal (terminal_inventory.terminal_id is a NOT NULL FK)
+    const slug = `s-${uuid.slice(0, 6)}`;
+    await env.DB.prepare(
+      `INSERT INTO shops (uuid, name, slug, game_version_id) VALUES (?, ?, ?, ?)`,
+    ).bind(crypto.randomUUID(), `Shop ${slug}`, slug, TEST_GAME_VERSION_ID).run();
+    const shop = await env.DB.prepare("SELECT id FROM shops WHERE slug=?").bind(slug).first<{ id: number }>();
+    await env.DB.prepare(
+      `INSERT INTO terminals (uuid, shop_id, shop_name_key, terminal_type, game_version_id) VALUES (?, ?, ?, 'item', ?)`,
+    ).bind(crypto.randomUUID(), shop!.id, slug, TEST_GAME_VERSION_ID).run();
+    const term = await env.DB.prepare("SELECT id FROM terminals WHERE shop_name_key=?").bind(slug).first<{ id: number }>();
+    await env.DB.prepare(
+      `INSERT INTO terminal_inventory (terminal_id, item_uuid, item_type, item_name, latest_buy_price, latest_source, latest_observed_at, game_version_id)
+       VALUES (?, ?, 'item', ?, 5000, 'uex', datetime('now'), ?)`,
+    ).bind(term!.id, uuid, name, TEST_GAME_VERSION_ID).run();
+  }
+
+  it("creates a searchable loot_map row for a UEX-only item, categorized by name", async () => {
+    const bombUuid = crypto.randomUUID();
+    await seedUexItem(bombUuid, "Colossus Bomb");
+    const made = await backfillBuyOnlyLootMap(env.DB, TEST_GAME_VERSION_ID);
+    expect(made).toBeGreaterThanOrEqual(1);
+    const row = await env.DB.prepare("SELECT name, category, data_source FROM loot_map WHERE uuid=?").bind(bombUuid).first();
+    expect(row).toMatchObject({ name: "Colossus Bomb", category: "ship_weapon", data_source: "terminal_inventory_backfill" });
+  });
+
+  it("assigns categories by name group", async () => {
+    const casing = crypto.randomUUID();
+    const nozzle = crypto.randomUUID();
+    const fab = crypto.randomUUID();
+    await seedUexItem(casing, "mobiGlas Amber Casing");
+    await seedUexItem(nozzle, "Harkin");
+    await seedUexItem(fab, "RediMake Item Fabricator");
+    await backfillBuyOnlyLootMap(env.DB, TEST_GAME_VERSION_ID);
+    const cat = async (u: string) => (await env.DB.prepare("SELECT category FROM loot_map WHERE uuid=?").bind(u).first<{ category: string }>())?.category;
+    expect(await cat(casing)).toBe("clothing");
+    expect(await cat(nozzle)).toBe("ship_component");
+    expect(await cat(fab)).toBe("misc");
+  });
+
+  it("is idempotent and skips placeholder / lowercase-junk items", async () => {
+    await seedUexItem(crypto.randomUUID(), "<= PLACEHOLDER =>");
+    await seedUexItem(crypto.randomUUID(), "aluminum");
+    const before = await env.DB.prepare("SELECT COUNT(*) n FROM loot_map WHERE data_source='terminal_inventory_backfill'").first<{ n: number }>();
+    const made = await backfillBuyOnlyLootMap(env.DB, TEST_GAME_VERSION_ID);
+    const after = await env.DB.prepare("SELECT COUNT(*) n FROM loot_map WHERE data_source='terminal_inventory_backfill'").first<{ n: number }>();
+    expect(made).toBe(0); // nothing new — placeholders/junk excluded, prior rows already exist
+    expect(after!.n).toBe(before!.n);
+  });
+});


### PR DESCRIPTION
## Durably backfill loot_map for buy-only items (#135)

Makes the #135 fix permanent. The p4k extractor builds `loot_map` only from items that appear in a loot table, so **buy-only** items (sold at shops, never lootable) fall through — unsearchable, with orphaned UEX prices (RediMake fabricator, ship bombs, refueling nozzles, ship modules, mobiGlas casings).

**Why this lives in the UEX sync, not the extractor:** 36 of the 37 such items have *no* extraction base price — they're known only from UEX community data. So neither the p4k extractor nor the load script can produce them; the UEX sync is where they become known.

`backfillBuyOnlyLootMap()` runs at the end of each UEX item sync: for any UEX-priced `item_type='item'` not already in `loot_map` (excluding placeholders / lowercase junk), it creates a minimal `loot_map` row keyed by the item's uuid → searchable, and "Where to Buy" (#139) links its prices automatically. Category assigned by name. **Idempotent and self-healing** — re-creates rows after a full DB reload on the next sync. The sync already purges the `loot:` cache, so search refreshes automatically.

Replaces the one-off SQL backfill (already applied to staging+prod) with a durable mechanism so it can't be silently dropped by a reload.

### Testing
- 3 new tests (creates row + categorizes by name, idempotent, skips placeholder/junk); full suite 652 pass.
- Behavior already proven in prod via the one-off backfill (37 items live + searchable).

Related: #139 (Where to Buy), #136 (closed — resolved).
