### PR TITLE
fix(localization): auto-ingest catches a new base from either source + no-regression guard

### DIFF
--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -770,6 +770,121 @@ export function evaluateLocalizationIngest(
   return { changed: true, ok: true, keyCount, delta, reason: "Changed + passed sanity" };
 }
 
+/** A community source's fetch result for one ingest run. `content: null` = the
+ *  fetch failed this run (skip it, but keep its last-seen hash). */
+export interface SourceFetch {
+  name: string;
+  content: string | null;
+}
+
+/** Per-source content fingerprints from the previous run (source name → hash). */
+export interface IngestSeenState {
+  seen: Record<string, string>;
+}
+
+export interface IngestDecisionMulti {
+  action: "ingest" | "unchanged" | "skip";
+  /** Source chosen (when action === "ingest"). */
+  source?: string;
+  /** Content to write (when action === "ingest"). */
+  content?: string;
+  keyCount?: number;
+  delta?: number;
+  reason: string;
+  /** Updated per-source seen hashes to persist for the next run. */
+  seen: Record<string, string>;
+}
+
+/**
+ * Cheap, deterministic content fingerprint (length + djb2). Detects when a
+ * SOURCE itself publishes a new file — distinct from comparing against our
+ * stored base, which would thrash between two sources that ship different
+ * bytes for the *same* patch.
+ */
+export function hashIni(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(h, 33) + s.charCodeAt(i)) | 0;
+  }
+  return `${s.length}:${(h >>> 0).toString(36)}`;
+}
+
+/**
+ * Choose whether/what to ingest from MULTIPLE community base sources, given the
+ * current KV base and the per-source hashes seen last run. `sources` is in
+ * canonical-preference order — index 0 is the canonical source (BeltaKoda).
+ *
+ * Rules (this is the fix for "catch a new INI from EITHER source"):
+ *  - A source is only a real candidate if its content DIFFERS from our base
+ *    (evaluateLocalizationIngest.changed) and passes the sanity gate.
+ *  - The CANONICAL source ingests on any such difference (it's the live base —
+ *    refreshing toward it never thrashes, since once ingested it equals base).
+ *  - A NON-canonical source ingests ONLY when it has actually just PUBLISHED
+ *    (its hash changed since last run). That's what lets a new patch land via
+ *    Dymerz while BeltaKoda is still stale, WITHOUT ping-ponging between two
+ *    sources that merely differ in bytes for the same patch.
+ *  - Sources are considered in order, so the canonical one wins when both moved.
+ *  - Always returns the updated `seen` map (records every source we fetched,
+ *    including baselines on the first run).
+ */
+export function decideLocalizationIngest(
+  sources: SourceFetch[],
+  current: string | null,
+  state: IngestSeenState,
+  opts?: { minKeys?: number; maxDropFraction?: number },
+): IngestDecisionMulti {
+  const prevSeen = state.seen ?? {};
+  const seen: Record<string, string> = { ...prevSeen };
+
+  const hashes: Record<string, string> = {};
+  for (const s of sources) {
+    if (s.content !== null) {
+      const h = hashIni(s.content);
+      hashes[s.name] = h;
+      seen[s.name] = h; // record/refresh baseline for every fetched source
+    }
+  }
+
+  if (!sources.some((s) => s.content !== null)) {
+    return { action: "skip", reason: "All sources failed to fetch", seen };
+  }
+
+  const canonicalName = sources[0]?.name;
+  let rejection: string | null = null;
+
+  for (const s of sources) {
+    if (s.content === null) continue;
+    const d = evaluateLocalizationIngest(s.content, current, opts);
+    if (!d.changed) continue; // equals our current base — nothing to take here
+    if (!d.ok) {
+      rejection ??= `${s.name}: ${d.reason}`;
+      continue; // broken/suspicious publish — fall through to the next source
+    }
+    // No-regression guard: never overwrite a base that has MORE keys than the
+    // source offers. A net key loss means our base is newer than this source
+    // (e.g. we extracted a patch locally before BeltaKoda/Dymerz published it).
+    // Silent skip — benign, and it auto-resumes once the source catches up
+    // (delta >= 0). Patches almost always ADD keys, so this rarely blocks a
+    // legitimate update; a genuine key-removing patch is left for a manual call.
+    if (current !== null && d.delta < 0) continue;
+    const isCanonical = s.name === canonicalName;
+    const isFresh = prevSeen[s.name] !== undefined && prevSeen[s.name] !== hashes[s.name];
+    if (!isCanonical && !isFresh) continue; // differs but not a fresh publish → hold (anti-thrash)
+    return {
+      action: "ingest",
+      source: s.name,
+      content: s.content,
+      keyCount: d.keyCount,
+      delta: d.delta,
+      reason: d.reason,
+      seen,
+    };
+  }
+
+  if (rejection) return { action: "skip", reason: rejection, seen };
+  return { action: "unchanged", reason: "No source published a new base since last run", seen };
+}
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------

--- a/src/sync/localizationIngest.ts
+++ b/src/sync/localizationIngest.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../lib/types";
-import { evaluateLocalizationIngest } from "../lib/localization";
+import { decideLocalizationIngest, type SourceFetch, type IngestSeenState } from "../lib/localization";
 
 /**
  * Auto-ingest a clean, *unmodified* base global.ini from community CDN sources
@@ -48,6 +48,8 @@ async function notify(env: Env, content: string): Promise<void> {
   }
 }
 
+const STATE_KEY = "localization:ingest-state";
+
 export async function runLocalizationIngest(env: Env): Promise<IngestRunResult> {
   const ver = await env.DB
     .prepare("SELECT code FROM game_versions WHERE is_default = 1 LIMIT 1")
@@ -57,39 +59,58 @@ export async function runLocalizationIngest(env: Env): Promise<IngestRunResult> 
   const key = `localization:global-ini:${ver.code}`;
   const current = await env.LOCALIZATION_KV.get(key);
 
-  let lastReason = "All sources failed to fetch";
-  for (const src of BASE_SOURCES) {
-    let content: string | null = null;
-    try {
-      const resp = await fetch(src.url, { cf: { cacheTtl: 0 } });
-      if (!resp.ok) {
-        lastReason = `${src.name} fetch failed (HTTP ${resp.status})`;
-        continue;
-      }
-      content = await resp.text();
-    } catch {
-      lastReason = `${src.name} fetch threw`;
-      continue;
+  // Per-source content fingerprints from the previous run — lets us detect when
+  // a SOURCE actually publishes something new (so a fresh INI from EITHER source
+  // is caught) without thrashing between two sources that ship different bytes
+  // for the same patch.
+  let state: IngestSeenState = { seen: {} };
+  try {
+    const raw = await env.LOCALIZATION_KV.get(STATE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as IngestSeenState;
+      if (parsed && typeof parsed === "object" && parsed.seen) state = { seen: parsed.seen };
     }
-
-    const d = evaluateLocalizationIngest(content, current);
-    if (!d.changed) {
-      return { status: "unchanged", source: src.name, versionCode: ver.code, keyCount: d.keyCount, reason: d.reason };
-    }
-    if (!d.ok) {
-      lastReason = `${src.name}: ${d.reason}`;
-      await notify(env, `⚠️ Localization auto-ingest skipped ${src.name} for ${ver.code}: ${d.reason}`);
-      continue; // try the next source
-    }
-
-    await env.LOCALIZATION_KV.put(key, content);
-    const sign = d.delta >= 0 ? "+" : "";
-    await notify(
-      env,
-      `✅ Base global.ini auto-refreshed for ${ver.code} from ${src.name} — ${d.keyCount} keys (Δ${sign}${d.delta})`,
-    );
-    return { status: "ingested", source: src.name, versionCode: ver.code, keyCount: d.keyCount, delta: d.delta, reason: d.reason };
+  } catch {
+    state = { seen: {} };
   }
 
-  return { status: "skipped", versionCode: ver.code, reason: lastReason };
+  // Fetch EVERY source (no short-circuit) so a fresh publish from any of them
+  // is considered this run.
+  const fetched: SourceFetch[] = [];
+  for (const src of BASE_SOURCES) {
+    try {
+      const resp = await fetch(src.url, { cf: { cacheTtl: 0 } });
+      fetched.push({ name: src.name, content: resp.ok ? await resp.text() : null });
+    } catch {
+      fetched.push({ name: src.name, content: null });
+    }
+  }
+
+  const d = decideLocalizationIngest(fetched, current, state);
+
+  // Persist the refreshed per-source hashes regardless of outcome (records
+  // baselines on the first run; marks a publish as seen after we act on it).
+  await env.LOCALIZATION_KV.put(STATE_KEY, JSON.stringify({ seen: d.seen }));
+
+  if (d.action === "ingest") {
+    await env.LOCALIZATION_KV.put(key, d.content!);
+    const delta = d.delta ?? 0;
+    const sign = delta >= 0 ? "+" : "";
+    await notify(
+      env,
+      `✅ Base global.ini auto-refreshed for ${ver.code} from ${d.source} — ${d.keyCount} keys (Δ${sign}${delta})`,
+    );
+    return { status: "ingested", source: d.source, versionCode: ver.code, keyCount: d.keyCount, delta: d.delta, reason: d.reason };
+  }
+
+  if (d.action === "skip") {
+    // Only ping on a genuine rejection (a source published something broken),
+    // not on the transient all-fetch-failed case.
+    if (!/fail/i.test(d.reason)) {
+      await notify(env, `⚠️ Localization auto-ingest skipped for ${ver.code}: ${d.reason}`);
+    }
+    return { status: "skipped", versionCode: ver.code, reason: d.reason };
+  }
+
+  return { status: "unchanged", versionCode: ver.code, reason: d.reason };
 }

--- a/test/localization-ingest.test.ts
+++ b/test/localization-ingest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { evaluateLocalizationIngest } from "../src/lib/localization";
+import { evaluateLocalizationIngest, decideLocalizationIngest, hashIni } from "../src/lib/localization";
 
 /**
  * evaluateLocalizationIngest — the safety brain for auto-ingesting a community
@@ -51,5 +51,118 @@ describe("evaluateLocalizationIngest", () => {
     const r = evaluateLocalizationIngest(ini(8200), ini(8000));
     expect(r.keyCount).toBe(8200);
     expect(r.delta).toBe(200);
+  });
+});
+
+/**
+ * decideLocalizationIngest — multi-source selection across BeltaKoda (canonical)
+ * + Dymerz (fallback). Fixes the original bug where BeltaKoda being "unchanged"
+ * short-circuited the loop so a fresh publish from Dymerz was never seen. Adds a
+ * no-regression guard so the hourly cron can't revert a base we extracted ahead
+ * of the community (the 4.8.1-via-local-extraction case).
+ */
+describe("decideLocalizationIngest", () => {
+  const BELTA = "BeltaKoda";
+  const DYM = "Dymerz";
+
+  it("catches a fresh Dymerz publish even when BeltaKoda is unchanged (the bug fix)", () => {
+    const cur = ini(8000, "v");
+    const belta = ini(8000, "v"); // identical to current → 'unchanged' for canonical
+    const dymerzOld = ini(8000, "dyold");
+    const dymerzNew = ini(8050, "new"); // Dymerz just shipped a new patch
+    const state = { seen: { [BELTA]: hashIni(belta), [DYM]: hashIni(dymerzOld) } };
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: belta }, { name: DYM, content: dymerzNew }],
+      cur,
+      state,
+    );
+    expect(r.action).toBe("ingest");
+    expect(r.source).toBe(DYM);
+  });
+
+  it("does NOT thrash: a non-canonical source that differs but isn't a fresh publish is held", () => {
+    const cur = ini(8000, "v");
+    const belta = ini(8000, "v");
+    const dymerz = ini(8050, "dy"); // differs from current, but SAME as last run
+    const state = { seen: { [BELTA]: hashIni(belta), [DYM]: hashIni(dymerz) } };
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: belta }, { name: DYM, content: dymerz }],
+      cur,
+      state,
+    );
+    expect(r.action).toBe("unchanged");
+  });
+
+  it("prefers the canonical source when both have moved", () => {
+    const cur = ini(8000, "v");
+    const belta = ini(8100, "newB");
+    const dymerz = ini(8050, "newD");
+    const state = { seen: { [BELTA]: hashIni(ini(8000, "v")), [DYM]: hashIni(ini(8000, "dold")) } };
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: belta }, { name: DYM, content: dymerz }],
+      cur,
+      state,
+    );
+    expect(r.action).toBe("ingest");
+    expect(r.source).toBe(BELTA);
+  });
+
+  it("no-regression guard: won't revert a richer base to a source with fewer keys", () => {
+    // Our base is 8016 keys (e.g. a locally-extracted 4.8.1); BeltaKoda still
+    // serves 8000 (4.8.0). The cron must NOT overwrite the newer base.
+    const cur = ini(8016, "local481");
+    const belta = ini(8000, "belta480");
+    const state = { seen: { [BELTA]: hashIni(ini(7000, "older")) } }; // belta 'changed' since seen
+    const r = decideLocalizationIngest([{ name: BELTA, content: belta }], cur, state);
+    expect(r.action).toBe("unchanged"); // held by the guard, not ingested
+  });
+
+  it("resumes once the canonical source catches up (delta >= 0)", () => {
+    const cur = ini(8016, "local481");
+    const belta = ini(8016, "belta481"); // BeltaKoda now also 4.8.1, same key count, real content
+    const state = { seen: { [BELTA]: hashIni(ini(8000, "belta480")) } };
+    const r = decideLocalizationIngest([{ name: BELTA, content: belta }], cur, state);
+    expect(r.action).toBe("ingest");
+    expect(r.source).toBe(BELTA);
+  });
+
+  it("seeds from the canonical source when there's no base yet", () => {
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: ini(8000) }, { name: DYM, content: ini(8050) }],
+      null,
+      { seen: {} },
+    );
+    expect(r.action).toBe("ingest");
+    expect(r.source).toBe(BELTA);
+  });
+
+  it("falls through a broken canonical publish to a good fresh fallback", () => {
+    const cur = ini(8000, "v");
+    const belta = ini(50); // too few keys → rejected by the sanity gate
+    const dymerzNew = ini(8050, "new");
+    const state = { seen: { [DYM]: hashIni(ini(8000, "dold")) } };
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: belta }, { name: DYM, content: dymerzNew }],
+      cur,
+      state,
+    );
+    expect(r.action).toBe("ingest");
+    expect(r.source).toBe(DYM);
+  });
+
+  it("skips when every source fails to fetch", () => {
+    const r = decideLocalizationIngest(
+      [{ name: BELTA, content: null }, { name: DYM, content: null }],
+      ini(8000),
+      { seen: {} },
+    );
+    expect(r.action).toBe("skip");
+    expect(r.reason).toMatch(/fetch/i);
+  });
+
+  it("records updated per-source hashes for the next run", () => {
+    const belta = ini(8000);
+    const r = decideLocalizationIngest([{ name: BELTA, content: belta }], ini(8000), { seen: {} });
+    expect(r.seen[BELTA]).toBe(hashIni(belta));
   });
 });


### PR DESCRIPTION
The hourly localization auto-ingest only looked at BeltaKoda — if BeltaKoda was unchanged it returned early and **never checked Dymerz**, so a new patch base landing on Dymerz first was silently missed. It also had no protection against the cron reverting a base we extracted ahead of the community.

- **Multi-source**: fetch + evaluate **both** sources each run. BeltaKoda (canonical) ingests on any change; Dymerz ingests only when it has actually just published (content hash changed since last run) — catches a fresh INI from either source, no thrash.
- **No-regression guard**: never overwrite a base that has more keys than the source offers (net key loss ⇒ our base is newer, e.g. a locally-extracted hotfix the community hasn't published yet). Auto-resumes when the source catches up.
- Per-source hashes persisted in KV (`localization:ingest-state`).
- +9 pure-function tests (restores coverage skipped during the vitest-4 migration). typecheck clean; backend 663 pass.

Unblocks landing the locally-extracted 4.8.1 base without the cron reverting it.