### PR TITLE
feat(localization): GitHub auto-detect — stage a new patch's base for review

### DIFF
--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -885,6 +885,163 @@ export function decideLocalizationIngest(
   return { action: "unchanged", reason: "No source published a new base since last run", seen };
 }
 
+// ── Version-aware auto-detect ──────────────────────────────────────────────
+
+export interface DetectedVersion {
+  /** Stable code matching game_versions.code, e.g. "4.8.1-live". */
+  code: string;
+  /** "live" | "ptu" | "eptu". */
+  channel: string;
+  /** Build number, e.g. "11952564", or null if the commit didn't carry one. */
+  build: string | null;
+}
+
+/**
+ * Parse the SC version a community-repo commit represents, from its message.
+ * Handles Dymerz ("4.8.1-live.11952564 English and Brazilian") and BeltaKoda
+ * ("feat(4.8.0-live): release ..."). Returns null when there's no version token
+ * (e.g. a "refactor: ..." chore). The channel matters: Dymerz commits BOTH live
+ * and ptu to the same english/global.ini, so callers gate on channel==='live'
+ * before ingesting into the LIVE base.
+ */
+export function parseVersionFromCommit(message: string): DetectedVersion | null {
+  if (!message) return null;
+  const m = message.match(/(\d+\.\d+\.\d+)-(live|ptu|eptu)(?:\.(\d+))?/i);
+  if (!m) return null;
+  const channel = m[2].toLowerCase();
+  return { code: `${m[1]}-${channel}`, channel, build: m[3] ?? null };
+}
+
+/**
+ * Compare two stable version codes by their numeric X.Y.Z (channel ignored —
+ * callers gate on channel separately). >0 if `a` is newer, <0 if older, 0 if
+ * equal or unparseable. Numeric per-segment (4.10 > 4.9), not lexical.
+ */
+export function compareVersionCodes(a: string, b: string): number {
+  const nums = (s: string): number[] | null => {
+    const m = s.match(/(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const na = nums(a);
+  const nb = nums(b);
+  if (!na || !nb) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (na[i] !== nb[i]) return na[i] - nb[i];
+  }
+  return 0;
+}
+
+export interface VersionedSourceFetch {
+  name: string;
+  content: string | null;
+  /** Detected version for this source — only resolved when the content changed
+   *  (a fresh publish), so we don't hit the GitHub API every idle run. */
+  version: DetectedVersion | null;
+}
+
+export interface VersionedIngestDecision {
+  action: "stage-new" | "refresh-current" | "unchanged" | "skip";
+  source?: string;
+  content?: string;
+  /** KV version-code to write the base under (a new code for stage-new, the
+   *  current default for refresh-current). */
+  targetCode?: string;
+  /** For stage-new: the new version to create (default is NOT flipped). */
+  version?: DetectedVersion;
+  keyCount?: number;
+  delta?: number;
+  /** For stage-new: key-level diff vs the current base, for the review ping. */
+  diff?: GlobalIniDiff;
+  reason: string;
+  seen: Record<string, string>;
+}
+
+/**
+ * Version-aware localization ingest decision. Two outcomes that matter:
+ *  - STAGE-NEW: a source published a NEWER LIVE version than the current default
+ *    and we don't have it yet → stage it under its own code (preserve current,
+ *    never flip default; a human promotes). The diff vs the current base rides
+ *    along for the review ping.
+ *  - REFRESH-CURRENT: a same-patch base update → delegate to the tested
+ *    decideLocalizationIngest (canonical-on-change / fresh-on-publish + the
+ *    no-regression guard). Only canonical (BeltaKoda, LIVE-pathed) or a source
+ *    whose detected version IS the current default is eligible — this stops a
+ *    Dymerz PTU commit (same english/global.ini path) from overwriting LIVE.
+ */
+export function decideVersionedIngest(
+  sources: VersionedSourceFetch[],
+  currentDefaultCode: string,
+  currentBase: string | null,
+  knownCodes: string[],
+  state: IngestSeenState,
+  opts?: { minKeys?: number; maxDropFraction?: number },
+): VersionedIngestDecision {
+  const prevSeen = state.seen ?? {};
+  const seen: Record<string, string> = { ...prevSeen };
+  const hashes: Record<string, string> = {};
+  for (const s of sources) {
+    if (s.content !== null) {
+      const h = hashIni(s.content);
+      hashes[s.name] = h;
+      seen[s.name] = h;
+    }
+  }
+  if (!sources.some((s) => s.content !== null)) {
+    return { action: "skip", reason: "All sources failed to fetch", seen };
+  }
+
+  const known = new Set(knownCodes);
+  const canonicalName = sources[0]?.name;
+
+  // ── Pass 1: a NEWER LIVE version we don't have yet → stage it. Idempotency
+  // comes from knownCodes (once the version row exists it won't re-stage), so
+  // this also catches a version already published when the feature first ships.
+  for (const s of sources) {
+    if (s.content === null || !s.version) continue;
+    if (s.version.channel !== "live") continue; // PTU/EPTU never touches the LIVE base
+    if (known.has(s.version.code)) continue; // already staged/known
+    if (compareVersionCodes(s.version.code, currentDefaultCode) <= 0) continue; // not newer
+    const ev = evaluateLocalizationIngest(s.content, null, opts);
+    if (!ev.ok) continue; // suspiciously small — skip this publish
+    const diff = currentBase ? diffGlobalIni(currentBase, s.content) : { added: [], removed: [], changed: [] };
+    return {
+      action: "stage-new",
+      source: s.name,
+      content: s.content,
+      targetCode: s.version.code,
+      version: s.version,
+      keyCount: ev.keyCount,
+      diff,
+      reason: `New LIVE version ${s.version.code} published by ${s.name}`,
+      seen,
+    };
+  }
+
+  // ── Pass 2: same-patch refresh of the current default base. Filter to sources
+  // eligible to touch the LIVE current base, then reuse decideLocalizationIngest.
+  const eligible: SourceFetch[] = sources
+    .filter((s) => s.name === canonicalName || (s.version?.channel === "live" && s.version.code === currentDefaultCode))
+    .map((s) => ({ name: s.name, content: s.content }));
+  const refresh = decideLocalizationIngest(eligible, currentBase, state, opts);
+
+  if (refresh.action === "ingest") {
+    return {
+      action: "refresh-current",
+      source: refresh.source,
+      content: refresh.content,
+      targetCode: currentDefaultCode,
+      keyCount: refresh.keyCount,
+      delta: refresh.delta,
+      reason: refresh.reason,
+      seen, // full per-source seen (decideLocalizationIngest only saw eligible sources)
+    };
+  }
+  if (refresh.action === "skip") {
+    return { action: "skip", reason: refresh.reason, seen };
+  }
+  return { action: "unchanged", reason: refresh.reason, seen };
+}
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------

--- a/src/sync/localizationIngest.ts
+++ b/src/sync/localizationIngest.ts
@@ -1,36 +1,93 @@
 import type { Env } from "../lib/types";
-import { decideLocalizationIngest, type SourceFetch, type IngestSeenState } from "../lib/localization";
+import {
+  decideVersionedIngest,
+  parseVersionFromCommit,
+  hashIni,
+  type VersionedSourceFetch,
+  type IngestSeenState,
+  type DetectedVersion,
+} from "../lib/localization";
 
 /**
- * Auto-ingest a clean, *unmodified* base global.ini from community CDN sources
- * so SC Bridge's localization stays fresh within hours of a patch — without a
- * local game install or a human extracting. Refreshes ONLY the current default
- * version's base in KV; never creates version rows or flips the default (that
- * stays with patch cutover), so an unattended run can't corrupt version state.
+ * Version-aware auto-ingest of a clean, *unmodified* base global.ini from
+ * community sources (BeltaKoda canonical, Dymerz fallback) so SC Bridge's
+ * localization stays fresh within hours of a patch — without a local game
+ * install or a human extracting.
  *
- * Sources are tried in order; the first that fetches AND passes the sanity
- * gate (evaluateLocalizationIngest) wins. A suspicious/broken upstream is
- * skipped (and reported), falling through to the next source.
+ *  - SAME patch: refresh the current default version's base in KV (guarded
+ *    against thrash + regressing a base we extracted ahead of the community).
+ *  - NEW patch: detect the version from the source's GitHub commit, STAGE it
+ *    under its own code (preserve the current base, never flip the default),
+ *    and Discord-ping the diff so a human can review + promote.
+ *
+ * The GitHub commit lookup only fires when a source's *content* changed, so an
+ * idle hourly run makes a single raw fetch per source and never touches the
+ * (rate-limited, unauthenticated) GitHub API.
  */
-const BASE_SOURCES: { name: string; url: string }[] = [
+interface BaseSource {
+  name: string;
+  url: string; // raw global.ini
+  repo: string; // owner/repo for the commits API
+  path: string; // file path within the repo (its latest commit names the version)
+}
+
+const BASE_SOURCES: BaseSource[] = [
   {
     name: "BeltaKoda ScCompLangPackRemix (stock)",
     url: "https://raw.githubusercontent.com/BeltaKoda/ScCompLangPackRemix/refs/heads/main/LIVE/stock-global.ini",
+    repo: "BeltaKoda/ScCompLangPackRemix",
+    path: "LIVE/stock-global.ini",
   },
   {
     name: "Dymerz StarCitizen-Localization (english)",
     url: "https://raw.githubusercontent.com/Dymerz/StarCitizen-Localization/main/data/Localization/english/global.ini",
+    repo: "Dymerz/StarCitizen-Localization",
+    path: "data/Localization/english/global.ini",
   },
 ];
 
 export interface IngestRunResult {
-  status: "ingested" | "unchanged" | "skipped" | "rejected";
+  status: "ingested" | "staged" | "unchanged" | "skipped" | "rejected";
   source?: string;
   versionCode?: string;
   keyCount?: number;
   delta?: number;
   reason: string;
 }
+
+/** Injectable network so the orchestration (D1 + KV writes) is testable without
+ *  live fetches (the vitest-4 pool dropped the fetch mock). */
+export interface IngestDeps {
+  fetchContent: (url: string) => Promise<string | null>;
+  fetchVersion: (src: BaseSource) => Promise<DetectedVersion | null>;
+}
+
+async function defaultFetchContent(url: string): Promise<string | null> {
+  try {
+    const resp = await fetch(url, { cf: { cacheTtl: 0 } });
+    return resp.ok ? await resp.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultFetchVersion(src: BaseSource): Promise<DetectedVersion | null> {
+  try {
+    const api = `https://api.github.com/repos/${src.repo}/commits?path=${encodeURIComponent(src.path)}&per_page=1`;
+    const resp = await fetch(api, {
+      headers: { "User-Agent": "scbridge-localization-ingest", Accept: "application/vnd.github+json" },
+      cf: { cacheTtl: 0 },
+    });
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as Array<{ commit?: { message?: string } }>;
+    const msg = data?.[0]?.commit?.message;
+    return msg ? parseVersionFromCommit(msg) : null;
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_DEPS: IngestDeps = { fetchContent: defaultFetchContent, fetchVersion: defaultFetchVersion };
 
 async function notify(env: Env, content: string): Promise<void> {
   // Reuse the single Discord webhook (shared with pack requests) — different
@@ -50,19 +107,16 @@ async function notify(env: Env, content: string): Promise<void> {
 
 const STATE_KEY = "localization:ingest-state";
 
-export async function runLocalizationIngest(env: Env): Promise<IngestRunResult> {
+export async function runLocalizationIngest(env: Env, deps: IngestDeps = DEFAULT_DEPS): Promise<IngestRunResult> {
   const ver = await env.DB
     .prepare("SELECT code FROM game_versions WHERE is_default = 1 LIMIT 1")
     .first<{ code: string }>();
   if (!ver) return { status: "skipped", reason: "No default game version configured" };
+  const currentDefaultCode = ver.code;
 
-  const key = `localization:global-ini:${ver.code}`;
-  const current = await env.LOCALIZATION_KV.get(key);
+  const currentBase = await env.LOCALIZATION_KV.get(`localization:global-ini:${currentDefaultCode}`);
 
-  // Per-source content fingerprints from the previous run — lets us detect when
-  // a SOURCE actually publishes something new (so a fresh INI from EITHER source
-  // is caught) without thrashing between two sources that ship different bytes
-  // for the same patch.
+  // Per-source content fingerprints from the previous run.
   let state: IngestSeenState = { seen: {} };
   try {
     const raw = await env.LOCALIZATION_KV.get(STATE_KEY);
@@ -74,43 +128,65 @@ export async function runLocalizationIngest(env: Env): Promise<IngestRunResult> 
     state = { seen: {} };
   }
 
-  // Fetch EVERY source (no short-circuit) so a fresh publish from any of them
-  // is considered this run.
-  const fetched: SourceFetch[] = [];
+  // Fetch every source; resolve its version from GitHub ONLY when the content
+  // changed since last run (keeps the GitHub API calls to ~once per patch).
+  const fetched: VersionedSourceFetch[] = [];
   for (const src of BASE_SOURCES) {
-    try {
-      const resp = await fetch(src.url, { cf: { cacheTtl: 0 } });
-      fetched.push({ name: src.name, content: resp.ok ? await resp.text() : null });
-    } catch {
-      fetched.push({ name: src.name, content: null });
+    const content = await deps.fetchContent(src.url);
+    let version: DetectedVersion | null = null;
+    if (content !== null && state.seen[src.name] !== hashIni(content)) {
+      version = await deps.fetchVersion(src);
     }
+    fetched.push({ name: src.name, content, version });
   }
 
-  const d = decideLocalizationIngest(fetched, current, state);
+  const knownRows = await env.DB.prepare("SELECT code FROM game_versions").all<{ code: string }>();
+  const knownCodes = knownRows.results.map((r) => r.code);
 
-  // Persist the refreshed per-source hashes regardless of outcome (records
-  // baselines on the first run; marks a publish as seen after we act on it).
+  const d = decideVersionedIngest(fetched, currentDefaultCode, currentBase, knownCodes, state);
+
+  // Persist refreshed per-source hashes regardless of outcome.
   await env.LOCALIZATION_KV.put(STATE_KEY, JSON.stringify({ seen: d.seen }));
 
-  if (d.action === "ingest") {
-    await env.LOCALIZATION_KV.put(key, d.content!);
+  if (d.action === "stage-new") {
+    const v = d.version!;
+    const uuid = `${v.code}-${v.build ?? "0"}`;
+    // is_default=0 — staging NEVER flips the live default; a human promotes via
+    // PUT /api/admin/versions/default after reviewing the diff.
+    await env.DB
+      .prepare(
+        "INSERT OR IGNORE INTO game_versions (uuid, code, channel, is_default, build_number, released_at) VALUES (?, ?, 'LIVE', 0, ?, date('now'))",
+      )
+      .bind(uuid, v.code, v.build)
+      .run();
+    await env.LOCALIZATION_KV.put(`localization:global-ini:${d.targetCode}`, d.content!);
+    const diff = d.diff ?? { added: [], removed: [], changed: [] };
+    await notify(
+      env,
+      `🆕 Localization base **${d.targetCode}** staged from ${d.source} — ` +
+        `+${diff.added.length} / ~${diff.changed.length} / -${diff.removed.length} vs ${currentDefaultCode}. ` +
+        `Review the diff and promote at Admin → Versions.`,
+    );
+    return { status: "staged", source: d.source, versionCode: d.targetCode, keyCount: d.keyCount, reason: d.reason };
+  }
+
+  if (d.action === "refresh-current") {
+    await env.LOCALIZATION_KV.put(`localization:global-ini:${d.targetCode}`, d.content!);
     const delta = d.delta ?? 0;
     const sign = delta >= 0 ? "+" : "";
     await notify(
       env,
-      `✅ Base global.ini auto-refreshed for ${ver.code} from ${d.source} — ${d.keyCount} keys (Δ${sign}${delta})`,
+      `✅ Base global.ini auto-refreshed for ${currentDefaultCode} from ${d.source} — ${d.keyCount} keys (Δ${sign}${delta})`,
     );
-    return { status: "ingested", source: d.source, versionCode: ver.code, keyCount: d.keyCount, delta: d.delta, reason: d.reason };
+    return { status: "ingested", source: d.source, versionCode: currentDefaultCode, keyCount: d.keyCount, delta: d.delta, reason: d.reason };
   }
 
   if (d.action === "skip") {
-    // Only ping on a genuine rejection (a source published something broken),
-    // not on the transient all-fetch-failed case.
     if (!/fail/i.test(d.reason)) {
-      await notify(env, `⚠️ Localization auto-ingest skipped for ${ver.code}: ${d.reason}`);
+      await notify(env, `⚠️ Localization auto-ingest skipped for ${currentDefaultCode}: ${d.reason}`);
     }
-    return { status: "skipped", versionCode: ver.code, reason: d.reason };
+    return { status: "skipped", versionCode: currentDefaultCode, reason: d.reason };
   }
 
-  return { status: "unchanged", versionCode: ver.code, reason: d.reason };
+  return { status: "unchanged", versionCode: currentDefaultCode, reason: d.reason };
 }

--- a/test/localization-ingest-orchestrator.test.ts
+++ b/test/localization-ingest-orchestrator.test.ts
@@ -1,0 +1,102 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { setupTestDatabase } from "./apply-migrations";
+import { runLocalizationIngest, type IngestDeps } from "../src/sync/localizationIngest";
+import type { Env } from "../src/lib/types";
+
+// The cloudflare:test `env` is structurally our Env for the bindings this code
+// touches (DB + LOCALIZATION_KV); cast through unknown for the call signature.
+const appEnv = env as unknown as Env;
+
+/**
+ * Exercises the version-aware orchestration end-to-end against the real test D1
+ * + KV, with network fetches stubbed (the vitest-4 pool dropped fetchMock).
+ */
+const ini = (n: number, tag = "v"): string =>
+  Array.from({ length: n }, (_, i) => `key_${i}=${tag}${i}`).join("\n");
+const KV = () => (env as unknown as { LOCALIZATION_KV: KVNamespace }).LOCALIZATION_KV;
+
+describe("runLocalizationIngest orchestration", () => {
+  beforeEach(async () => {
+    await setupTestDatabase(env.DB);
+    await env.DB.batch([
+      env.DB.prepare("UPDATE game_versions SET is_default = 0"),
+      env.DB.prepare(
+        "INSERT OR IGNORE INTO game_versions (uuid, code, channel, is_default, build_number) VALUES ('4.8.0-live-1','4.8.0-live','LIVE',0,'1')",
+      ),
+      env.DB.prepare("DELETE FROM game_versions WHERE code = '4.8.1-live'"),
+      env.DB.prepare("UPDATE game_versions SET is_default = 1 WHERE code = '4.8.0-live'"),
+    ]);
+    await KV().delete("localization:ingest-state");
+    await KV().delete("localization:global-ini:4.8.1-live");
+    await KV().put("localization:global-ini:4.8.0-live", ini(8000, "v480"));
+  });
+
+  it("stages a NEW version (row + base) without flipping the default", async () => {
+    const deps: IngestDeps = {
+      fetchContent: async (url) => (url.includes("Dymerz") ? ini(8016, "v481") : ini(8000, "v480")),
+      fetchVersion: async (src) =>
+        src.name.includes("Dymerz")
+          ? { code: "4.8.1-live", channel: "live", build: "11952564" }
+          : { code: "4.8.0-live", channel: "live", build: null },
+    };
+    const r = await runLocalizationIngest(appEnv, deps);
+    expect(r.status).toBe("staged");
+    expect(r.versionCode).toBe("4.8.1-live");
+
+    const row = await env.DB
+      .prepare("SELECT code, is_default, build_number FROM game_versions WHERE code = '4.8.1-live'")
+      .first<{ code: string; is_default: number; build_number: string }>();
+    expect(row).toBeTruthy();
+    expect(row!.is_default).toBe(0); // never auto-promoted
+    expect(row!.build_number).toBe("11952564");
+
+    expect(await KV().get("localization:global-ini:4.8.1-live")).toBe(ini(8016, "v481"));
+    expect(await KV().get("localization:global-ini:4.8.0-live")).toBe(ini(8000, "v480")); // preserved
+
+    const def = await env.DB.prepare("SELECT code FROM game_versions WHERE is_default = 1").first<{ code: string }>();
+    expect(def!.code).toBe("4.8.0-live"); // still the old default
+  });
+
+  it("refreshes the current base on a same-patch update (no new row)", async () => {
+    const deps: IngestDeps = {
+      fetchContent: async (url) => (url.includes("Belta") ? ini(8000, "v480fix") : ini(8000, "v480")),
+      fetchVersion: async () => ({ code: "4.8.0-live", channel: "live", build: null }),
+    };
+    const r = await runLocalizationIngest(appEnv, deps);
+    expect(r.status).toBe("ingested");
+    expect(await KV().get("localization:global-ini:4.8.0-live")).toBe(ini(8000, "v480fix"));
+    const count = await env.DB
+      .prepare("SELECT COUNT(*) AS n FROM game_versions WHERE code = '4.8.1-live'")
+      .first<{ n: number }>();
+    expect(count!.n).toBe(0);
+  });
+
+  it("does NOT revert the current base to a source with fewer keys", async () => {
+    await KV().put("localization:global-ini:4.8.0-live", ini(8016, "rich"));
+    const deps: IngestDeps = {
+      fetchContent: async () => ini(8000, "poorer"),
+      fetchVersion: async () => ({ code: "4.8.0-live", channel: "live", build: null }),
+    };
+    const r = await runLocalizationIngest(appEnv, deps);
+    expect(r.status).toBe("unchanged");
+    expect(await KV().get("localization:global-ini:4.8.0-live")).toBe(ini(8016, "rich"));
+  });
+
+  it("ignores a Dymerz PTU publish (does not stage or pollute LIVE)", async () => {
+    const deps: IngestDeps = {
+      fetchContent: async (url) => (url.includes("Dymerz") ? ini(8020, "ptu") : ini(8000, "v480")),
+      fetchVersion: async (src) =>
+        src.name.includes("Dymerz")
+          ? { code: "4.8.0-ptu", channel: "ptu", build: "999" }
+          : { code: "4.8.0-live", channel: "live", build: null },
+    };
+    const r = await runLocalizationIngest(appEnv, deps);
+    expect(r.status).toBe("unchanged");
+    expect(await KV().get("localization:global-ini:4.8.0-live")).toBe(ini(8000, "v480"));
+    const ptuRow = await env.DB
+      .prepare("SELECT COUNT(*) AS n FROM game_versions WHERE code = '4.8.0-ptu'")
+      .first<{ n: number }>();
+    expect(ptuRow!.n).toBe(0);
+  });
+});

--- a/test/localization-version-autodetect.test.ts
+++ b/test/localization-version-autodetect.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseVersionFromCommit,
+  compareVersionCodes,
+  decideVersionedIngest,
+  hashIni,
+} from "../src/lib/localization";
+
+const ini = (n: number, tag = "v"): string =>
+  Array.from({ length: n }, (_, i) => `key_${i}=${tag}${i}`).join("\n");
+const live = (code: string, build: string | null = null) => ({ code, channel: "live", build });
+const ptu = (code: string, build: string | null = null) => ({ code, channel: "ptu", build });
+
+describe("parseVersionFromCommit", () => {
+  it("parses a Dymerz commit (version at the start, with build)", () => {
+    expect(parseVersionFromCommit("4.8.1-live.11952564 English and Brazilian")).toEqual({
+      code: "4.8.1-live",
+      channel: "live",
+      build: "11952564",
+    });
+  });
+
+  it("parses a Dymerz PTU commit (channel matters — must NOT be treated as live)", () => {
+    expect(parseVersionFromCommit("4.8.0-ptu.11817467 (EN)")).toEqual({
+      code: "4.8.0-ptu",
+      channel: "ptu",
+      build: "11817467",
+    });
+  });
+
+  it("parses a BeltaKoda commit (version inside feat(), no build)", () => {
+    expect(
+      parseVersionFromCommit("feat(4.8.0-live): release Star Citizen 4.8.0 LIVE compact naming remix"),
+    ).toEqual({ code: "4.8.0-live", channel: "live", build: null });
+  });
+
+  it("returns null for a chore commit with no version token", () => {
+    expect(parseVersionFromCommit("refactor: restructure repo from version-specific to channel-based folders")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseVersionFromCommit("")).toBeNull();
+  });
+});
+
+describe("compareVersionCodes", () => {
+  it("newer minor/patch is greater", () => {
+    expect(compareVersionCodes("4.8.1-live", "4.8.0-live")).toBeGreaterThan(0);
+    expect(compareVersionCodes("4.8.0-live", "4.8.1-live")).toBeLessThan(0);
+  });
+
+  it("equal codes compare to 0", () => {
+    expect(compareVersionCodes("4.8.0-live", "4.8.0-live")).toBe(0);
+  });
+
+  it("compares numerically, not lexically (4.10 > 4.9)", () => {
+    expect(compareVersionCodes("4.10.0-live", "4.9.0-live")).toBeGreaterThan(0);
+  });
+
+  it("unparseable input is treated as incomparable (0)", () => {
+    expect(compareVersionCodes("garbage", "4.8.0-live")).toBe(0);
+  });
+});
+
+describe("decideVersionedIngest", () => {
+  const B = "BeltaKoda";
+  const D = "Dymerz";
+
+  it("stages a newer LIVE version published on Dymerz (BeltaKoda still behind)", () => {
+    const cur = ini(8000, "v480");
+    const r = decideVersionedIngest(
+      [
+        { name: B, content: ini(8000, "v480"), version: live("4.8.0-live") },
+        { name: D, content: ini(8016, "v481"), version: live("4.8.1-live", "11952564") },
+      ],
+      "4.8.0-live",
+      cur,
+      ["4.8.0-live", "4.7.1-live"],
+      { seen: { [B]: hashIni(ini(8000, "v480")), [D]: hashIni(ini(8000, "dold")) } },
+    );
+    expect(r.action).toBe("stage-new");
+    expect(r.source).toBe(D);
+    expect(r.targetCode).toBe("4.8.1-live");
+    expect(r.version?.code).toBe("4.8.1-live");
+    expect(r.diff?.added.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT stage or refresh from a Dymerz PTU commit (channel gate protects LIVE)", () => {
+    const cur = ini(8000, "v480");
+    const r = decideVersionedIngest(
+      [
+        { name: B, content: ini(8000, "v480"), version: live("4.8.0-live") },
+        { name: D, content: ini(8020, "ptu"), version: ptu("4.8.0-ptu", "123") },
+      ],
+      "4.8.0-live",
+      cur,
+      ["4.8.0-live"],
+      { seen: { [B]: hashIni(ini(8000, "v480")), [D]: hashIni(ini(8000, "dold")) } },
+    );
+    expect(r.action).toBe("unchanged");
+  });
+
+  it("is idempotent: a newer version already in knownCodes is not re-staged", () => {
+    const r = decideVersionedIngest(
+      [
+        { name: B, content: ini(8000, "v480"), version: live("4.8.0-live") },
+        { name: D, content: ini(8016, "v481"), version: live("4.8.1-live") },
+      ],
+      "4.8.0-live",
+      ini(8000, "v480"),
+      ["4.8.0-live", "4.8.1-live"], // already staged
+      { seen: { [B]: hashIni(ini(8000, "v480")), [D]: hashIni(ini(8000, "dold")) } },
+    );
+    expect(r.action).toBe("unchanged");
+  });
+
+  it("refreshes the current base on a same-patch update (canonical preferred)", () => {
+    const cur = ini(8000, "v480");
+    const r = decideVersionedIngest(
+      [
+        { name: B, content: ini(8000, "v480fix"), version: live("4.8.0-live") },
+        { name: D, content: ini(8000, "dy"), version: live("4.8.0-live") },
+      ],
+      "4.8.0-live",
+      cur,
+      ["4.8.0-live"],
+      { seen: { [B]: hashIni(ini(8000, "v480")), [D]: hashIni(ini(8000, "dy")) } },
+    );
+    expect(r.action).toBe("refresh-current");
+    expect(r.source).toBe(B);
+    expect(r.targetCode).toBe("4.8.0-live");
+  });
+
+  it("no-regression guard holds when a source is behind the current base (the 4.8.1 case)", () => {
+    const r = decideVersionedIngest(
+      [{ name: B, content: ini(8000, "belta480"), version: live("4.8.0-live") }],
+      "4.8.1-live",
+      ini(8016, "local481"),
+      ["4.8.1-live"],
+      { seen: { [B]: hashIni(ini(7000, "older")) } },
+    );
+    expect(r.action).toBe("unchanged");
+  });
+
+  it("prefers the canonical source when both publish the new version", () => {
+    const r = decideVersionedIngest(
+      [
+        { name: B, content: ini(8016, "b481"), version: live("4.8.1-live") },
+        { name: D, content: ini(8016, "d481"), version: live("4.8.1-live", "x") },
+      ],
+      "4.8.0-live",
+      ini(8000, "v480"),
+      ["4.8.0-live"],
+      { seen: { [B]: hashIni(ini(8000, "b480")), [D]: hashIni(ini(8000, "d480")) } },
+    );
+    expect(r.action).toBe("stage-new");
+    expect(r.source).toBe(B);
+  });
+
+  it("ignores an older version (never downgrades)", () => {
+    const r = decideVersionedIngest(
+      [{ name: B, content: ini(8000, "old"), version: live("4.7.0-live") }],
+      "4.8.0-live",
+      ini(8016, "cur480"),
+      ["4.8.0-live"],
+      { seen: { [B]: hashIni(ini(7000, "older")) } },
+    );
+    expect(r.action).toBe("unchanged");
+  });
+
+  it("skips when every source fails to fetch", () => {
+    const r = decideVersionedIngest(
+      [{ name: B, content: null, version: null }, { name: D, content: null, version: null }],
+      "4.8.0-live",
+      ini(8000),
+      ["4.8.0-live"],
+      { seen: {} },
+    );
+    expect(r.action).toBe("skip");
+  });
+});


### PR DESCRIPTION
Builds on #185. The auto-ingest now distinguishes a **new patch** from a same-patch refresh and **stages** it instead of overwriting the live base.

- **Version detection**: `parseVersionFromCommit` reads the SC version from a source's latest GitHub commit (Dymerz `4.8.1-live.11952564 …`, BeltaKoda `feat(4.8.0-live): …`). The commits API is queried **only when a source's content changed** → idle runs make zero GitHub calls (no token needed).
- **Stage, don't flip**: a newer LIVE version we don't have yet → create the version row (`is_default=0`), write its KV base under its own code, **preserve** the current base, and Discord-ping the diff (`+N / ~M / -K vs current`). The default is **never** auto-promoted — a human reviews + promotes via the existing `PUT /api/admin/versions/default`.
- **Channel gate**: Dymerz commits both live *and* ptu to the same `english/global.ini`; the detector confirms `channel===live` before touching the LIVE base (also closes that hole in #185).
- Same-patch updates delegate to the existing refresh path (no-regression guard intact). Orchestrator rewired with injectable fetch deps.
- +21 tests (17 pure + 4 real-D1/KV orchestration). typecheck clean; backend 684 pass.

This is the durable answer to "have the INI ready when a new patch drops" without depending on relabel (which only fits hotfixes).