### PR TITLE
feat(loot): surface ship bomb stats on item detail pages

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1447,6 +1447,17 @@ export async function getLootByUuid(db: D1Database, uuid: string, isPTU = false)
       .first() as Record<string, unknown> | null;
   }
 
+  // Fallback: ship_weapon ordnance (bombs/missiles) without FK — match by UUID
+  // to ship_missiles. The buy-only bombs (Colossus/Stormburst/Thunderball) get a
+  // ship_weapon loot_map row from the UEX backfill with ship_missile_id=NULL, so
+  // they miss the vehicle_components fallback above; their stats live here.
+  if (!details && item.category === 'ship_weapon') {
+    details = await db
+      .prepare(`SELECT name, type, sub_type, size, grade, description, missile_type, lock_time, tracking_signal, damage, damage_type, blast_radius, speed, lock_range, ammo_count FROM ${t("ship_missiles")} WHERE uuid = ?`)
+      .bind(uuid)
+      .first() as Record<string, unknown> | null;
+  }
+
   // Fetch locations from junction table, resolving UUIDs to display names.
   // 9 vestigial cols were dropped in migration 0203 (buy_price/sell_price →
   // terminal_inventory; contract_name/guild/reward_type/reward_amount/reward_max/amount

--- a/test/loot-bomb.test.ts
+++ b/test/loot-bomb.test.ts
@@ -1,0 +1,35 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { setupTestDatabase } from "./apply-migrations";
+import { getLootByUuid } from "../src/db/queries";
+
+// Ship bombs (Colossus/Stormburst/Thunderball) live in ship_missiles, but their
+// UEX-backfill loot_map rows are category='ship_weapon' with ship_missile_id=NULL,
+// so they resolve via the ship_missiles UUID-fallback in getLootByUuid.
+describe("getLootByUuid — ship bomb stats via ship_missiles fallback", () => {
+  const COLOSSUS = "2b8a744d-c0a0-4f92-b0e6-bf4ae077cc11";
+
+  beforeAll(async () => {
+    await setupTestDatabase(env.DB);
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO ship_missiles (uuid, name, type, sub_type, size, grade, missile_type, damage, damage_type, blast_radius, ammo_count, game_version_id)
+         VALUES (?, 'Colossus Bomb', 'Bomb', 'Bomb', 10, 'A', 'Bomb', 568296.99, 'Physical, Energy', 250, 1, 1)`,
+      ).bind(COLOSSUS),
+      env.DB.prepare(
+        `INSERT INTO loot_map (uuid, name, category, vehicle_component_id, ship_missile_id, data_source, game_version_id)
+         VALUES (?, 'Colossus Bomb', 'ship_weapon', NULL, NULL, 'terminal_inventory_backfill', 1)`,
+      ).bind(COLOSSUS),
+    ]);
+  });
+
+  it("surfaces blast radius + damage for a ship_weapon bomb not in vehicle_components", async () => {
+    const row = await getLootByUuid(env.DB, COLOSSUS);
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe("Colossus Bomb");
+    const det = row!.item_details as Record<string, unknown>;
+    expect(det.blast_radius).toBe(250);
+    expect(det.damage).toBe(568296.99);
+    expect(det.damage_type).toBe("Physical, Energy");
+  });
+});


### PR DESCRIPTION
Phase B.2 (fleet-manager half). The buy-only bombs get a `ship_weapon` loot_map row (UEX backfill, `ship_missile_id=NULL`) so they fell through the vehicle_components UUID-fallback and showed no stats. Add a `ship_missiles` UUID-fallback for `ship_weapon` items → blast radius + damage (populated by tools#3) surface via the existing missile/combat stat groups. +1 backend test. Harmless until the batched 4.8.1 pipeline run populates the bomb stats.