### PR TITLE
feat(loot): show crafted items in collection with quantities (#92)

### DIFF
--- a/frontend/src/pages/LootDB/ItemCard.jsx
+++ b/frontend/src/pages/LootDB/ItemCard.jsx
@@ -1,10 +1,10 @@
-import { Bookmark, BookmarkPlus, Check } from 'lucide-react'
+import { Bookmark, BookmarkPlus, Check, Package } from 'lucide-react'
 import { rarityStyle, CATEGORY_BADGE_STYLES, CATEGORY_LABELS, effectiveCategory, humanizeRawDisplayName } from '../../lib/lootDisplay'
 import SourceIcons from './SourceIcons'
 import CollectionStepper from './CollectionStepper'
 import ItemCardStats from './ItemCardStats'
 
-export default function ItemCard({ item, collectionQty, onSetCollectionQty, wishlisted, onToggleWishlist, isAuthed, onSelect }) {
+export default function ItemCard({ item, collectionQty, craftedQty = 0, onSetCollectionQty, wishlisted, onToggleWishlist, isAuthed, onSelect }) {
   const rs = rarityStyle(item.rarity)
   const eCat = effectiveCategory(item)
   const catStyle = CATEGORY_BADGE_STYLES[eCat] || CATEGORY_BADGE_STYLES.unknown
@@ -44,6 +44,15 @@ export default function ItemCard({ item, collectionQty, onSetCollectionQty, wish
         {item.rarity && item.rarity !== 'N/A' && (
           <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${rs.badge}`}>
             {item.rarity}
+          </span>
+        )}
+        {isAuthed && craftedQty > 0 && (
+          <span
+            className="flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded border border-emerald-500/30 bg-emerald-500/10 text-emerald-300/90"
+            title={`${craftedQty} crafted via My Blueprints`}
+          >
+            <Package className="w-3 h-3" />
+            {craftedQty}
           </span>
         )}
       </div>

--- a/frontend/src/pages/LootDB/index.jsx
+++ b/frontend/src/pages/LootDB/index.jsx
@@ -27,6 +27,7 @@ import {
 import {
   extractSetName, PAGE_SIZE_GRID, PAGE_SIZE_LIST,
   buildShoppingList, groupWishlistItems, groupWishlistByLocation, getPrimarySource, SOURCE_DEFS,
+  matchesShowFilter,
 } from './lootHelpers'
 import SourceIcons from './SourceIcons'
 import CollectionStepper from './CollectionStepper'
@@ -67,6 +68,7 @@ const SHOW_OPTIONS = [
   { value: 'collected', label: 'Collected' },
   { value: 'uncollected', label: 'Uncollected' },
   { value: 'wishlisted', label: 'Wishlisted' },
+  { value: 'crafted', label: 'Crafted' },
 ]
 
 // ── Shopping List Modal ─────────────────────────────────────────────────────
@@ -346,13 +348,10 @@ export default function LootDB() {
       }
     }
 
-    // Show filter (collection/wishlist overlay)
-    if (show === 'collected') {
-      items = items.filter((i) => collected.has(i.uuid))
-    } else if (show === 'uncollected') {
-      items = items.filter((i) => !collected.has(i.uuid))
-    } else if (show === 'wishlisted') {
-      items = items.filter((i) => wishlistIds.has(i.uuid))
+    // Show filter (collection/wishlist/crafted overlay). Crafted items count as
+    // owned, so 'collected' includes them and 'uncollected' excludes them (#92).
+    if (show !== 'all') {
+      items = items.filter((i) => matchesShowFilter(i, show, { collected, wishlistIds, craftedMap }))
     }
 
     if (search.trim()) {
@@ -393,7 +392,7 @@ export default function LootDB() {
     }
 
     return items
-  }, [allItems, category, brand, setName, rarities, sources, search, sortBy, show, filterDimensions, filterIncludes, filterExcludes, collected, wishlistIds])
+  }, [allItems, category, brand, setName, rarities, sources, search, sortBy, show, filterDimensions, filterIncludes, filterExcludes, collected, wishlistIds, craftedMap])
 
   const pageSize = viewMode === 'grid' ? PAGE_SIZE_GRID : PAGE_SIZE_LIST
   const totalPages = Math.ceil(filtered.length / pageSize)
@@ -851,6 +850,7 @@ export default function LootDB() {
                   key={item.id}
                   item={item}
                   collectionQty={collected.get(item.uuid) ?? 0}
+                  craftedQty={craftedMap?.[item.uuid] ?? 0}
                   onSetCollectionQty={handleSetCollectionQty}
                   wishlisted={wishlistIds.has(item.uuid)}
                   onToggleWishlist={handleToggleWishlist}
@@ -867,6 +867,7 @@ export default function LootDB() {
                 const catStyle = CATEGORY_BADGE_STYLES[eCat] || CATEGORY_BADGE_STYLES.unknown
                 const catLabel = CATEGORY_LABELS[eCat] || eCat
                 const itemCollectionQty = collected.get(item.uuid) ?? 0
+                const itemCraftedQty = craftedMap?.[item.uuid] ?? 0
                 const isWishlisted = wishlistIds.has(item.uuid)
                 return (
                   <div
@@ -885,6 +886,15 @@ export default function LootDB() {
                     {item.rarity && rs && (
                       <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${rs.badge} shrink-0`}>
                         {item.rarity}
+                      </span>
+                    )}
+                    {isAuthed && itemCraftedQty > 0 && (
+                      <span
+                        className="flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded border border-emerald-500/30 bg-emerald-500/10 text-emerald-300/90 shrink-0"
+                        title={`${itemCraftedQty} crafted via My Blueprints`}
+                      >
+                        <Package className="w-3 h-3" />
+                        {itemCraftedQty}
                       </span>
                     )}
                     <SourceIcons item={item} />

--- a/frontend/src/pages/LootDB/lootHelpers.js
+++ b/frontend/src/pages/LootDB/lootHelpers.js
@@ -51,6 +51,24 @@ export function formatStaleness(unixSec, nowSec = Math.floor(Date.now() / 1000))
   return `${Math.floor(ageSec / 86400)}d`
 }
 
+// ── Show filter predicate (collection / wishlist / crafted overlay) ───────────
+// A crafted item is something you "have" just like a looted one (#92), so the
+// "collected" view includes crafted items and "uncollected" excludes them.
+// ctx: { collected: Map<uuid,qty>, wishlistIds: Set<uuid>, craftedMap: Record<uuid,qty> }
+export function matchesShowFilter(item, show, ctx) {
+  const { collected, wishlistIds, craftedMap } = ctx
+  const uuid = item.uuid
+  const isCrafted = (craftedMap?.[uuid] ?? 0) > 0
+  const hasIt = collected.has(uuid) || isCrafted
+  switch (show) {
+    case 'collected':   return hasIt
+    case 'uncollected': return !hasIt
+    case 'wishlisted':  return wishlistIds.has(uuid)
+    case 'crafted':     return isCrafted
+    default:            return true // 'all' and any unknown value
+  }
+}
+
 // ── Location entry resolver ───────────────────────────────────────────────────
 export function resolveLocationEntry(entry, type) {
   if (typeof entry === 'string') return { label: entry, detail: null, probability: null }

--- a/frontend/src/pages/LootDB/lootHelpers.test.js
+++ b/frontend/src/pages/LootDB/lootHelpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatStaleness, resolveLocationEntry } from './lootHelpers'
+import { formatStaleness, resolveLocationEntry, matchesShowFilter } from './lootHelpers'
 
 // 2026-06-01 UTC — anchor for deterministic age calculations.
 const NOW = Math.floor(new Date('2026-06-01T00:00:00Z').getTime() / 1000)
@@ -78,5 +78,63 @@ describe('resolveLocationEntry — shops with UEX staleness', () => {
       'shops',
     )
     expect(r.detail).toBe('Price unknown')
+  })
+})
+
+describe('matchesShowFilter — collection/wishlist/crafted overlay (#92)', () => {
+  // uuids: looted, crafted, both-wishlisted, none
+  const looted = { uuid: 'u-looted' }
+  const crafted = { uuid: 'u-crafted' }
+  const wished = { uuid: 'u-wished' }
+  const plain = { uuid: 'u-plain' }
+
+  const ctx = {
+    collected: new Map([['u-looted', 2]]),
+    wishlistIds: new Set(['u-wished']),
+    craftedMap: { 'u-crafted': 3 },
+  }
+
+  it('"all" matches every item', () => {
+    for (const item of [looted, crafted, wished, plain]) {
+      expect(matchesShowFilter(item, 'all', ctx)).toBe(true)
+    }
+  })
+
+  it('"collected" includes both looted AND crafted items', () => {
+    expect(matchesShowFilter(looted, 'collected', ctx)).toBe(true)
+    expect(matchesShowFilter(crafted, 'collected', ctx)).toBe(true)
+    expect(matchesShowFilter(wished, 'collected', ctx)).toBe(false)
+    expect(matchesShowFilter(plain, 'collected', ctx)).toBe(false)
+  })
+
+  it('"uncollected" excludes anything you have (looted or crafted)', () => {
+    expect(matchesShowFilter(looted, 'uncollected', ctx)).toBe(false)
+    expect(matchesShowFilter(crafted, 'uncollected', ctx)).toBe(false)
+    expect(matchesShowFilter(wished, 'uncollected', ctx)).toBe(true)
+    expect(matchesShowFilter(plain, 'uncollected', ctx)).toBe(true)
+  })
+
+  it('"wishlisted" matches only wishlisted items', () => {
+    expect(matchesShowFilter(wished, 'wishlisted', ctx)).toBe(true)
+    expect(matchesShowFilter(looted, 'wishlisted', ctx)).toBe(false)
+  })
+
+  it('"crafted" matches only items with a crafted quantity > 0', () => {
+    expect(matchesShowFilter(crafted, 'crafted', ctx)).toBe(true)
+    expect(matchesShowFilter(looted, 'crafted', ctx)).toBe(false)
+    expect(matchesShowFilter(plain, 'crafted', ctx)).toBe(false)
+  })
+
+  it('treats a zero crafted quantity as not-crafted', () => {
+    const zeroCtx = { ...ctx, craftedMap: { 'u-crafted': 0 } }
+    expect(matchesShowFilter(crafted, 'crafted', zeroCtx)).toBe(false)
+    expect(matchesShowFilter(crafted, 'collected', zeroCtx)).toBe(false)
+  })
+
+  it('tolerates a missing craftedMap (unauthed / not yet loaded)', () => {
+    const noCrafted = { collected: new Map(), wishlistIds: new Set(), craftedMap: undefined }
+    expect(matchesShowFilter(crafted, 'crafted', noCrafted)).toBe(false)
+    expect(matchesShowFilter(crafted, 'collected', noCrafted)).toBe(false)
+    expect(matchesShowFilter(crafted, 'all', noCrafted)).toBe(true)
   })
 })


### PR DESCRIPTION
## What
Surfaces user-crafted items in the LootDB collection alongside looted ones, with quantities.

- New **Crafted** show-filter on LootDB.
- Crafted items count as *owned*: the **Collected** filter now includes them and **Uncollected** excludes them.
- Crafted-quantity badge (Package icon, emerald) on item cards and list rows.
- Extracted the show-filter predicate into a pure, unit-tested `matchesShowFilter` helper.

## Why
Issue #92 — the backend (`GET /api/loot/crafted`, summing `user_blueprints` + `user_blueprint_builds`) already existed and was shown only as a passive badge in the detail slide-over. This wires `craftedMap` through to the main grid/list and filtering so crafted items are browsable in the collection.

## Tests
- 8 new cases for `matchesShowFilter` (all/collected/uncollected/wishlisted/crafted, zero-qty, missing map).
- Frontend: 335 pass. Backend: 685 pass. typecheck + build clean.

Closes #92