### PR TITLE
feat(loadout): location planner — where to buy your loadout (#94)

### DIFF
--- a/frontend/src/pages/Loadout/LocationPlanner.jsx
+++ b/frontend/src/pages/Loadout/LocationPlanner.jsx
@@ -1,0 +1,87 @@
+import React, { useState, useMemo } from 'react'
+import { MapPin, ChevronDown, ChevronRight, ShoppingCart } from 'lucide-react'
+import { groupLoadoutByLocation, fmtInt } from './loadoutHelpers'
+
+// #94 — expandable "Location Planner" below the loadout builder. Shows where to
+// buy each component in the active loadout, grouped by the cheapest shop, with a
+// per-shop subtotal and a grand total. Components with no buyable shop fall into
+// a "Loot only" bucket. Shop data already rides on each component (loadout.ts
+// shopMap), so this is a pure client-side aggregation — no extra fetch.
+export default function LocationPlanner({ components }) {
+  const [open, setOpen] = useState(false)
+  const { groups, lootOnly, totalCost } = useMemo(
+    () => groupLoadoutByLocation(components),
+    [components],
+  )
+
+  const shopCount = groups.length
+  if (shopCount === 0 && lootOnly.length === 0) return null
+
+  return (
+    <div className="panel overflow-hidden">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-4 py-3 hover:bg-white/[0.02] transition-colors"
+      >
+        {open ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronRight className="w-4 h-4 text-gray-400" />}
+        <MapPin className="w-4 h-4 text-sc-accent" />
+        <span className="text-sm font-medium text-gray-200">Location Planner</span>
+        <span className="text-xs text-gray-500">
+          {shopCount} shop{shopCount !== 1 ? 's' : ''}
+          {lootOnly.length > 0 && ` · ${lootOnly.length} loot-only`}
+        </span>
+        {totalCost > 0 && (
+          <span className="ml-auto text-xs text-amber-300 flex items-center gap-1">
+            <ShoppingCart className="w-3 h-3" />
+            {fmtInt(totalCost)} aUEC
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="border-t border-white/[0.06]">
+          <p className="px-4 pt-3 text-[11px] text-gray-500">
+            Cheapest shop per component. Use the cart’s <span className="text-gray-400">Optimize Shops</span> for a
+            minimum-stops route.
+          </p>
+          {groups.map((g, gi) => (
+            <div key={gi} className="border-b border-white/[0.04] last:border-b-0">
+              <div className="px-4 py-2 bg-white/[0.03] flex items-center justify-between">
+                <div className="flex items-center gap-2 min-w-0">
+                  <MapPin className="w-3 h-3 text-gray-500 shrink-0" />
+                  <span className="text-xs font-medium text-gray-300 truncate">{g.shop_name || 'Unknown shop'}</span>
+                  {g.location_label && <span className="text-[11px] text-gray-500 truncate">{g.location_label}</span>}
+                </div>
+                <span className="text-xs text-amber-300 shrink-0">{fmtInt(g.subtotal)} aUEC</span>
+              </div>
+              <ul>
+                {g.items.map((item, ii) => (
+                  <li key={ii} className="flex items-center justify-between gap-3 px-4 py-1.5 hover:bg-white/[0.02] transition-colors">
+                    <span className="text-sm text-gray-300 truncate">{item.name}</span>
+                    <span className="text-[11px] font-mono text-gray-500 shrink-0">{fmtInt(item.buy_price)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          {lootOnly.length > 0 && (
+            <div>
+              <div className="px-4 py-2 bg-white/[0.03] flex items-center gap-2">
+                <span className="text-xs font-medium text-gray-400">Loot only</span>
+                <span className="text-[11px] text-gray-500">not sold at any known shop</span>
+              </div>
+              <ul>
+                {lootOnly.map((item, ii) => (
+                  <li key={ii} className="px-4 py-1.5 text-sm text-gray-400 truncate hover:bg-white/[0.02] transition-colors">
+                    {item.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Loadout/index.jsx
+++ b/frontend/src/pages/Loadout/index.jsx
@@ -14,6 +14,7 @@ import DamageBreakdown from './DamageBreakdown'
 import PowerPips from './PowerPips'
 import ModulesSection from './ModulesSection'
 import PaintsSection from './PaintsSection'
+import LocationPlanner from './LocationPlanner'
 import { PORT_TYPE_ICONS, PORT_CATEGORY_ORDER, getPortCategory, getPrimaryStat, aggregateCombatStats, fmtInt, fmtCompact, fmtDec1, fmtSpeed, getDamageType, DmgShape } from './loadoutHelpers'
 
 export default function Loadout() {
@@ -114,6 +115,12 @@ export default function Loadout() {
     return aggregateCombatStats(merged)
   }, [stockComponents, overrides])
 
+  // Effective loadout (stock with overrides applied) for the Location Planner (#94)
+  const effectiveComponents = useMemo(() => {
+    if (!stockComponents) return []
+    return stockComponents.map(c => overrides[c.port_id] ? { ...c, ...overrides[c.port_id] } : c)
+  }, [stockComponents, overrides])
+
   // Auto-collapse Point Defense section when >6 items
   useEffect(() => {
     const pdcGroup = grouped.find(g => g.label === 'Point Defense')
@@ -139,6 +146,7 @@ export default function Loadout() {
           port_id: portId, component_id: component.id,
           child_name: component.name, component_name: component.name,
           component_uuid: component.uuid,
+          shops: component.shops, // keep accurate buy locations for the Location Planner (#94)
           type: component.type, size: component.size, grade: component.grade,
           manufacturer_name: component.manufacturer_name,
           power_output: component.power_output, cooling_rate: component.cooling_rate,
@@ -458,6 +466,11 @@ export default function Loadout() {
             />
           </div>
         )}
+
+        {/* LOCATION PLANNER — where to buy the active loadout's components (#94) */}
+        <div className="mt-4">
+          <LocationPlanner components={effectiveComponents} />
+        </div>
       </div>
       </>}
 

--- a/frontend/src/pages/Loadout/loadoutHelpers.jsx
+++ b/frontend/src/pages/Loadout/loadoutHelpers.jsx
@@ -330,3 +330,47 @@ export function aggregateCombatStats(components) {
     totalPowerOutput, totalPowerDraw, totalCoolingRate,
   }
 }
+
+// ─── Location planner (#94) ─────────────────────────────────────────────────
+// Group the active loadout's components by the cheapest shop that sells each,
+// producing a "go here for these items" shopping plan. Components carry a
+// `shops` array ({ shop_name, location_label, buy_price }) from the
+// /api/loadout/:slug/components response (loadout.ts shopMap). Components with
+// no buyable shop entry fall into `lootOnly`.
+export function groupLoadoutByLocation(components) {
+  const empty = { groups: [], lootOnly: [], totalCost: 0 }
+  if (!Array.isArray(components) || components.length === 0) return empty
+
+  const groups = new Map() // key → { shop_name, location_label, items, subtotal }
+  const lootOnly = []
+
+  for (const comp of components) {
+    const name = comp.name || comp.component_name || comp.child_name || 'Component'
+    const buyable = (comp.shops || []).filter((s) => Number(s.buy_price) > 0)
+    if (buyable.length === 0) {
+      lootOnly.push({ name })
+      continue
+    }
+    // Cheapest shop wins (optimized per-item; the cart's "Optimize" does true
+    // set-cover across shops — this is the lighter inline summary).
+    const best = buyable.reduce((a, b) => (Number(b.buy_price) < Number(a.buy_price) ? b : a))
+    const key = [best.shop_name, best.location_label].filter(Boolean).join(' · ') || 'Unknown shop'
+    if (!groups.has(key)) {
+      groups.set(key, { shop_name: best.shop_name || null, location_label: best.location_label || null, items: [], subtotal: 0 })
+    }
+    const g = groups.get(key)
+    g.items.push({ name, buy_price: Number(best.buy_price) })
+    g.subtotal += Number(best.buy_price)
+  }
+
+  const ordered = [...groups.values()].sort((a, b) =>
+    (a.shop_name || '').localeCompare(b.shop_name || ''),
+  )
+  for (const g of ordered) g.items.sort((a, b) => a.name.localeCompare(b.name))
+
+  return {
+    groups: ordered,
+    lootOnly: lootOnly.sort((a, b) => a.name.localeCompare(b.name)),
+    totalCost: ordered.reduce((sum, g) => sum + g.subtotal, 0),
+  }
+}

--- a/frontend/src/pages/Loadout/loadoutHelpers.test.jsx
+++ b/frontend/src/pages/Loadout/loadoutHelpers.test.jsx
@@ -3,6 +3,7 @@ import {
   fmtInt, fmtCompact, fmtDec1, fmtPct, fmtSpeed, fmtRange, fmtRPM,
   getPortCategory, getDamageType, aggregateCombatStats,
   PORT_CATEGORY_ORDER, COMPONENT_TYPE_TO_PORT_TYPE,
+  groupLoadoutByLocation,
 } from './loadoutHelpers'
 
 
@@ -311,5 +312,60 @@ describe('COMPONENT_TYPE_TO_PORT_TYPE', () => {
     expect(COMPONENT_TYPE_TO_PORT_TYPE.QuantumDrive).toBe('quantum_drive')
     expect(COMPONENT_TYPE_TO_PORT_TYPE.WeaponGun).toBe('weapon')
     expect(COMPONENT_TYPE_TO_PORT_TYPE.Radar).toBe('sensor')
+  })
+})
+
+describe('groupLoadoutByLocation (#94)', () => {
+  const cooler = {
+    name: 'Cooler A',
+    shops: [
+      { shop_name: 'Dumper\'s Depot', location_label: 'Area18', buy_price: 5000 },
+      { shop_name: 'CenterMass', location_label: 'New Babbage', buy_price: 4200 },
+    ],
+  }
+  const shield = {
+    name: 'Shield B',
+    shops: [{ shop_name: 'CenterMass', location_label: 'New Babbage', buy_price: 12000 }],
+  }
+  const lootOnlyComp = { name: 'Rare PowerPlant', shops: [] }
+  const noPriceComp = { name: 'Broken Listing', shops: [{ shop_name: 'X', location_label: 'Y', buy_price: 0 }] }
+
+  it('groups each component under its cheapest shop', () => {
+    const { groups } = groupLoadoutByLocation([cooler, shield])
+    const center = groups.find((g) => g.shop_name === 'CenterMass')
+    expect(center).toBeTruthy()
+    // cooler is cheapest at CenterMass (4200) and shield only at CenterMass (12000)
+    const names = center.items.map((i) => i.name).sort()
+    expect(names).toEqual(['Cooler A', 'Shield B'])
+    expect(center.subtotal).toBe(4200 + 12000)
+  })
+
+  it('does not list a component at a pricier shop once it picks the cheapest', () => {
+    const { groups } = groupLoadoutByLocation([cooler])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].shop_name).toBe('CenterMass')
+    expect(groups[0].items[0].buy_price).toBe(4200)
+  })
+
+  it('buckets shopless / zero-price components into lootOnly', () => {
+    const { lootOnly } = groupLoadoutByLocation([lootOnlyComp, noPriceComp])
+    expect(lootOnly.map((i) => i.name).sort()).toEqual(['Broken Listing', 'Rare PowerPlant'])
+  })
+
+  it('computes a grand total across all shop groups', () => {
+    const { totalCost } = groupLoadoutByLocation([cooler, shield])
+    expect(totalCost).toBe(4200 + 12000)
+  })
+
+  it('sorts groups by shop name and tolerates empty input', () => {
+    expect(groupLoadoutByLocation([])).toEqual({ groups: [], lootOnly: [], totalCost: 0 })
+    expect(groupLoadoutByLocation(null)).toEqual({ groups: [], lootOnly: [], totalCost: 0 })
+  })
+
+  it('accepts component_name as a fallback label', () => {
+    const { groups } = groupLoadoutByLocation([
+      { component_name: 'Legacy Named', shops: [{ shop_name: 'S', location_label: 'L', buy_price: 100 }] },
+    ])
+    expect(groups[0].items[0].name).toBe('Legacy Named')
   })
 })


### PR DESCRIPTION
## What
An expandable **Location Planner** below the loadout builder that shows where to acquire each component in the active loadout, grouped by the cheapest shop, with per-shop subtotals and a grand total. Components not sold anywhere fall into a **Loot only** bucket.

## Why
Issue #94 — the shop data already rides on each component from `/api/loadout/:slug/components` (the `shopMap` join), so this is a pure client-side aggregation with **no extra request**. The cart's *Optimize Shops* still does true set-cover for a minimum-stops route; this is the lighter always-available inline summary.

## Notes
- Swapped components now carry their `shops` onto the override object, so the planner stays accurate after a component swap.
- Logic lives in a pure, unit-tested helper `groupLoadoutByLocation` (6 cases: cheapest-shop grouping, loot-only bucket, totals, empty/null input, label fallback).

## Tests
Frontend 334 pass (incl. 6 new), typecheck + build clean.

Closes #94