### PR TITLE
feat(poi): add quality/rarity filter to POI loot pools (#95)

### DIFF
--- a/frontend/src/pages/POI/POILootPool.jsx
+++ b/frontend/src/pages/POI/POILootPool.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { Package } from 'lucide-react'
 import SearchInput from '../../components/SearchInput'
 import {
-  RARITY_STYLES, CATEGORY_LABELS, CATEGORY_BADGE_STYLES, CATEGORY_ORDER,
+  RARITY_STYLES, RARITY_ORDER, CATEGORY_LABELS, CATEGORY_BADGE_STYLES, CATEGORY_ORDER,
   humanizeRawDisplayName,
 } from '../../lib/lootDisplay'
 
@@ -24,26 +24,30 @@ function pct(n) {
 export default function POILootPool({ envelope }) {
   const [query, setQuery] = useState('')
   const [category, setCategory] = useState('all')
+  const [rarity, setRarity] = useState('all')
 
   const pools = envelope.data || []
 
-  // Merge + filter items across pools for the current category/search so the
-  // filter chips operate over everything visible on screen at once.
-  const { visiblePools, categoryCounts } = useMemo(() => {
+  // Merge + filter items across pools for the current category/rarity/search so
+  // the filter chips operate over everything visible on screen at once.
+  const { visiblePools, categoryCounts, rarityCounts } = useMemo(() => {
     const q = query.trim().toLowerCase()
     const counts = { all: 0 }
+    const rCounts = {}
     const out = pools.map(pool => {
       const filtered = pool.items.filter(item => {
         counts.all++
         counts[item.category] = (counts[item.category] || 0) + 1
+        if (item.rarity) rCounts[item.rarity] = (rCounts[item.rarity] || 0) + 1
         if (category !== 'all' && item.category !== category) return false
+        if (rarity !== 'all' && item.rarity !== rarity) return false
         if (q && !item.name.toLowerCase().includes(q)) return false
         return true
       })
       return { ...pool, filteredItems: filtered }
     })
-    return { visiblePools: out, categoryCounts: counts }
-  }, [pools, query, category])
+    return { visiblePools: out, categoryCounts: counts, rarityCounts: rCounts }
+  }, [pools, query, category, rarity])
 
   if (envelope.partial && envelope.count === 0) {
     return (
@@ -59,6 +63,7 @@ export default function POILootPool({ envelope }) {
 
   const totalItems = pools.reduce((sum, p) => sum + p.items.length, 0)
   const orderedCats = ['all', ...CATEGORY_ORDER.filter(c => categoryCounts[c] > 0)]
+  const presentRarities = RARITY_ORDER.filter(r => rarityCounts[r] > 0)
 
   return (
     <section className="space-y-4">
@@ -92,6 +97,38 @@ export default function POILootPool({ envelope }) {
           ))}
         </div>
       </div>
+
+      {/* Rarity / quality filter (#95) — only shown when items carry rarity */}
+      {presentRarities.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap items-center">
+          <span className="text-[10px] font-display uppercase tracking-wider text-gray-600 mr-1">Quality</span>
+          <button
+            onClick={() => setRarity('all')}
+            className={`px-2.5 py-1 text-[10px] font-display uppercase tracking-wide rounded border transition-colors ${
+              rarity === 'all'
+                ? 'text-sc-accent border-sc-accent/40 bg-sc-accent/10'
+                : 'text-gray-500 border-sc-border hover:text-gray-300'
+            }`}
+          >
+            All ({categoryCounts.all || 0})
+          </button>
+          {presentRarities.map(r => {
+            const rs = RARITY_STYLES[r]
+            const active = rarity === r
+            return (
+              <button
+                key={r}
+                onClick={() => setRarity(active ? 'all' : r)}
+                className={`px-2.5 py-1 text-[10px] font-mono rounded border transition-colors ${
+                  active ? rs.badge : 'text-gray-500 border-sc-border hover:text-gray-300'
+                }`}
+              >
+                {r} ({rarityCounts[r]})
+              </button>
+            )
+          })}
+        </div>
+      )}
 
       {visiblePools.map(pool => {
         if (pool.filteredItems.length === 0) return null

--- a/frontend/src/pages/POI/POILootPool.test.jsx
+++ b/frontend/src/pages/POI/POILootPool.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import POILootPool from './POILootPool'
+
+// One pool with a mix of rarities so we can exercise the quality filter (#95).
+const ENVELOPE = {
+  count: 1,
+  data: [
+    {
+      loot_table: 'LootTable.Test',
+      container_type: 'Crate',
+      rolls: 3,
+      items: [
+        { uuid: 'i-common', name: 'Common Widget', category: 'weapon', rarity: 'Common', per_roll: 0.5, per_container_odds: 0.8 },
+        { uuid: 'i-rare', name: 'Rare Gizmo', category: 'weapon', rarity: 'Rare', per_roll: 0.1, per_container_odds: 0.27 },
+        { uuid: 'i-legendary', name: 'Legendary Doohickey', category: 'armour', rarity: 'Legendary', per_roll: 0.01, per_container_odds: 0.03 },
+      ],
+    },
+  ],
+}
+
+function renderPool(envelope = ENVELOPE) {
+  return render(
+    <MemoryRouter>
+      <POILootPool envelope={envelope} />
+    </MemoryRouter>,
+  )
+}
+
+describe('POILootPool — quality/rarity filter (#95)', () => {
+  it('renders a quality chip per present rarity with counts', () => {
+    renderPool()
+    expect(screen.getByRole('button', { name: /Common \(1\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Rare \(1\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Legendary \(1\)/ })).toBeInTheDocument()
+  })
+
+  it('filtering by Rare shows only the rare item', () => {
+    renderPool()
+    fireEvent.click(screen.getByRole('button', { name: /Rare \(1\)/ }))
+    const table = screen.getByRole('table')
+    expect(within(table).getByText('Rare Gizmo')).toBeInTheDocument()
+    expect(within(table).queryByText('Common Widget')).not.toBeInTheDocument()
+    expect(within(table).queryByText('Legendary Doohickey')).not.toBeInTheDocument()
+  })
+
+  it('clicking the active rarity chip again clears the filter', () => {
+    renderPool()
+    const rareChip = screen.getByRole('button', { name: /Rare \(1\)/ })
+    fireEvent.click(rareChip)
+    fireEvent.click(rareChip)
+    const table = screen.getByRole('table')
+    expect(within(table).getByText('Common Widget')).toBeInTheDocument()
+    expect(within(table).getByText('Legendary Doohickey')).toBeInTheDocument()
+  })
+
+  it('rarity and category filters compose (Rare + Armour = empty)', () => {
+    renderPool()
+    // Rare items are all weapons here, so Rare + Armour yields nothing.
+    fireEvent.click(screen.getByRole('button', { name: /Rare \(1\)/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Armour \(1\)/ }))
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('omits the quality row entirely when no item carries a rarity', () => {
+    const noRarity = {
+      count: 1,
+      data: [{ loot_table: 'LT', container_type: 'Crate', rolls: 1, items: [
+        { uuid: 'x', name: 'Plain', category: 'weapon', rarity: null, per_roll: 0.5, per_container_odds: 0.5 },
+      ] }],
+    }
+    renderPool(noRarity)
+    expect(screen.queryByText('Quality')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What
Adds a **Quality** (rarity) filter chip row to POI detail loot pools, mirroring the LootDB rarity filter.

- Chips render only for rarities actually present in the pool, each with a count.
- Composes with the existing category filter and search.
- Clicking the active chip clears the filter.
- The whole row is hidden when no item carries a rarity.

## Why
Issue #95 — the backend already returns `rarity` on each loot-pool item; this surfaces it as a filter so players can narrow a POI's drops to the quality tier they care about.

## Tests
5 new component tests (chips render, Rare filters, toggle-off clears, rarity+category compose, hidden when absent). Frontend 333 pass, typecheck + build clean.

Closes #95