### PR TITLE
feat(ships): salvageable ships browse page (#85)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ const AnalysisHistory = lazy(() => import('./pages/AnalysisHistory'))
 const Import = lazy(() => import('./pages/Import'))
 const ShipDB = lazy(() => import('./pages/ShipDB'))
 const ShipDetail = lazy(() => import('./pages/ShipDetail'))
+const Salvageable = lazy(() => import('./pages/Salvageable'))
 const Settings = lazy(() => import('./pages/Settings'))
 const Admin = lazy(() => import('./pages/Admin'))
 const UserManagement = lazy(() => import('./pages/UserManagement'))
@@ -103,6 +104,7 @@ const referenceGroup = {
   icon: BookOpen,
   items: [
     { to: '/ships', icon: Database, label: 'Ship DB' },
+    { to: '/salvageable', icon: Wrench, label: 'Salvageable Ships' },
     { to: '/paints', icon: Palette, label: 'Paints' },
     { to: '/careers', icon: Briefcase, label: 'Careers & Roles' },
     { to: '/law', icon: Scale, label: 'Law System' },
@@ -713,6 +715,7 @@ export default function App() {
 
                       {/* Public game data routes */}
                       <Route path="/ships" element={<ShipDB />} />
+                      <Route path="/salvageable" element={<Salvageable />} />
                       <Route path="/ships/:slug" element={<ShipDetail />} />
                       <Route path="/paints" element={<PaintBrowser />} />
                       <Route path="/paints/:slug" element={<PaintDetail />} />

--- a/frontend/src/pages/Salvageable.jsx
+++ b/frontend/src/pages/Salvageable.jsx
@@ -1,0 +1,126 @@
+import React, { useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Wrench } from 'lucide-react'
+import { useSalvageableShips } from '../hooks/useAPI'
+import PageHeader from '../components/PageHeader'
+import LoadingState from '../components/LoadingState'
+import ErrorState from '../components/ErrorState'
+import SearchInput from '../components/SearchInput'
+import ShipImage from '../components/ShipImage'
+import { collectVariantTypes, filterSalvageableShips, variantLabel } from './salvageableHelpers'
+
+export default function Salvageable() {
+  const { data: ships, loading, error, refetch } = useSalvageableShips()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const search = searchParams.get('q') || ''
+  const variant = searchParams.get('variant') || 'all'
+
+  const setSearch = (val) => setSearchParams((prev) => {
+    const next = new URLSearchParams(prev)
+    if (val) next.set('q', val); else next.delete('q')
+    return next
+  }, { replace: true })
+
+  const setVariant = (val) => setSearchParams((prev) => {
+    const next = new URLSearchParams(prev)
+    if (val && val !== 'all') next.set('variant', val); else next.delete('variant')
+    return next
+  }, { replace: true })
+
+  const variantTypes = useMemo(() => collectVariantTypes(ships), [ships])
+  const filtered = useMemo(
+    () => filterSalvageableShips(ships, { search, variant }),
+    [ships, search, variant],
+  )
+
+  if (loading) return <LoadingState message="Loading salvageable ships..." />
+  if (error) return <ErrorState message={error} onRetry={refetch} />
+
+  return (
+    <div className="space-y-4 animate-fade-in-up">
+      <PageHeader
+        title="SALVAGEABLE SHIPS"
+        subtitle={`${ships?.length || 0} ships with salvageable variants`}
+        actions={<Wrench className="w-5 h-5 text-gray-500" />}
+      />
+
+      <SearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder="Search salvageable ships..."
+        className="max-w-md"
+      />
+
+      {variantTypes.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap items-center">
+          <button
+            onClick={() => setVariant('all')}
+            className={`px-2.5 py-1 text-[10px] font-display uppercase tracking-wide rounded border transition-colors ${
+              variant === 'all'
+                ? 'text-sc-accent border-sc-accent/40 bg-sc-accent/10'
+                : 'text-gray-500 border-sc-border hover:text-gray-300'
+            }`}
+          >
+            All ({ships?.length || 0})
+          </button>
+          {variantTypes.map((vt) => (
+            <button
+              key={vt}
+              onClick={() => setVariant(variant === vt ? 'all' : vt)}
+              className={`px-2.5 py-1 text-[10px] font-display uppercase tracking-wide rounded border transition-colors ${
+                variant === vt
+                  ? 'text-sc-accent border-sc-accent/40 bg-sc-accent/10'
+                  : 'text-gray-500 border-sc-border hover:text-gray-300'
+              }`}
+            >
+              {variantLabel(vt)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="text-xs font-mono text-gray-500">{filtered.length} results</div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((ship) => (
+          <Link
+            key={ship.slug}
+            to={`/ships/${ship.slug}?tab=salvage`}
+            className="panel-hover group cursor-pointer overflow-hidden block"
+          >
+            <ShipImage
+              src={ship.image_url_small}
+              alt={ship.name}
+              aspectRatio="landscape"
+              hoverZoom
+            />
+            <div className="p-4">
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <div className="min-w-0">
+                  <h3 className="font-display font-semibold text-white text-sm line-clamp-2 leading-tight">{ship.name}</h3>
+                  <span className="text-xs text-gray-400 mt-1 block">{ship.manufacturer_name}</span>
+                </div>
+                <span className="badge badge-size shrink-0">
+                  {ship.variant_count} variant{ship.variant_count !== 1 ? 's' : ''}
+                </span>
+              </div>
+              <div className="mt-3 pt-2 border-t border-sc-border/30 flex flex-wrap gap-1.5">
+                {(ship.variant_types || '').split(',').map((s) => s.trim()).filter(Boolean).map((vt) => (
+                  <span key={vt} className="text-[10px] font-display uppercase tracking-wide px-1.5 py-0.5 rounded border border-sc-accent2/30 text-sc-accent2 bg-sc-accent2/10">
+                    {variantLabel(vt)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-16 text-gray-500 font-mono text-sm">
+          No salvageable ships match your filters.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/salvageableHelpers.js
+++ b/frontend/src/pages/salvageableHelpers.js
@@ -1,0 +1,42 @@
+// Helpers for the Salvageable ships browse page (#85). The API returns
+// variant_types as a comma-separated string (GROUP_CONCAT) per ship.
+
+export const VARIANT_LABELS = {
+  derelict_salvage: 'Derelict (Salvage)',
+  derelict: 'Derelict',
+  boarded: 'Boarded (Mission)',
+}
+
+export function variantLabel(type) {
+  return VARIANT_LABELS[type] || type
+}
+
+// Split a ship's comma-separated variant_types into a clean array.
+export function shipVariantTypes(ship) {
+  return String(ship?.variant_types || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+// All distinct variant types across the dataset, sorted, for the filter chips.
+export function collectVariantTypes(ships) {
+  const set = new Set()
+  for (const s of ships || []) {
+    for (const v of shipVariantTypes(s)) set.add(v)
+  }
+  return [...set].sort()
+}
+
+// Filter by free-text (name / manufacturer) and a single variant type.
+export function filterSalvageableShips(ships, { search = '', variant = 'all' } = {}) {
+  const q = search.trim().toLowerCase()
+  return (ships || []).filter((s) => {
+    if (variant !== 'all' && !shipVariantTypes(s).includes(variant)) return false
+    if (q) {
+      const hay = `${s.name || ''} ${s.manufacturer_name || ''}`.toLowerCase()
+      if (!hay.includes(q)) return false
+    }
+    return true
+  })
+}

--- a/frontend/src/pages/salvageableHelpers.test.js
+++ b/frontend/src/pages/salvageableHelpers.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shipVariantTypes, collectVariantTypes, filterSalvageableShips, variantLabel,
+} from './salvageableHelpers'
+
+const SHIPS = [
+  { slug: 'cutlass-black', name: 'Cutlass Black', manufacturer_name: 'Drake', variant_types: 'derelict_salvage, boarded', variant_count: 2 },
+  { slug: 'reclaimer', name: 'Reclaimer', manufacturer_name: 'Aegis', variant_types: 'derelict', variant_count: 1 },
+  { slug: 'vulture', name: 'Vulture', manufacturer_name: 'Drake', variant_types: '', variant_count: 0 },
+]
+
+describe('shipVariantTypes', () => {
+  it('splits and trims the comma-separated string', () => {
+    expect(shipVariantTypes(SHIPS[0])).toEqual(['derelict_salvage', 'boarded'])
+  })
+  it('returns [] for empty/missing', () => {
+    expect(shipVariantTypes(SHIPS[2])).toEqual([])
+    expect(shipVariantTypes({})).toEqual([])
+  })
+})
+
+describe('collectVariantTypes', () => {
+  it('returns the sorted distinct set across all ships', () => {
+    expect(collectVariantTypes(SHIPS)).toEqual(['boarded', 'derelict', 'derelict_salvage'])
+  })
+  it('tolerates null', () => {
+    expect(collectVariantTypes(null)).toEqual([])
+  })
+})
+
+describe('filterSalvageableShips', () => {
+  it('returns all ships with no filters', () => {
+    expect(filterSalvageableShips(SHIPS)).toHaveLength(3)
+  })
+  it('filters by variant type', () => {
+    const r = filterSalvageableShips(SHIPS, { variant: 'derelict' })
+    expect(r.map((s) => s.slug)).toEqual(['reclaimer'])
+  })
+  it('matches a ship that has the variant among several', () => {
+    const r = filterSalvageableShips(SHIPS, { variant: 'boarded' })
+    expect(r.map((s) => s.slug)).toEqual(['cutlass-black'])
+  })
+  it('searches name and manufacturer case-insensitively', () => {
+    expect(filterSalvageableShips(SHIPS, { search: 'drake' }).map((s) => s.slug)).toEqual(['cutlass-black', 'vulture'])
+    expect(filterSalvageableShips(SHIPS, { search: 'recl' }).map((s) => s.slug)).toEqual(['reclaimer'])
+  })
+  it('composes search and variant', () => {
+    expect(filterSalvageableShips(SHIPS, { search: 'drake', variant: 'boarded' }).map((s) => s.slug)).toEqual(['cutlass-black'])
+  })
+})
+
+describe('variantLabel', () => {
+  it('maps known types and falls back to the raw value', () => {
+    expect(variantLabel('derelict_salvage')).toBe('Derelict (Salvage)')
+    expect(variantLabel('mystery')).toBe('mystery')
+  })
+})


### PR DESCRIPTION
## What
A new **/salvageable** browse page listing every ship with salvageable variants, with search (name/manufacturer) and variant-type filter chips. Each card shows the ship image, manufacturer, variant count, and variant-type badges, linking through to `/ships/:slug?tab=salvage`.

## Why
Issue #85 — all the backend already existed (`GET /api/gamedata/salvageable-ships`, `listSalvageableShips`, `useSalvageableShips`) but the hook was never called and there was no page. This surfaces it: nav item added under **Reference**, route at `/salvageable`.

## Tests
10 new unit tests for the pure filter/parse helpers (`shipVariantTypes`, `collectVariantTypes`, `filterSalvageableShips`, `variantLabel`). Frontend 338 pass, typecheck + build clean.

Closes #85