### PR TITLE
feat(bench): weapon bench frontend core (#200)

### DIFF
--- a/frontend/src/pages/Crafting/QualitySim.jsx
+++ b/frontend/src/pages/Crafting/QualitySim.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react'
-import { Gem, HelpCircle, Bookmark, Check, Trash2, Plus } from 'lucide-react'
+import { HelpCircle, Bookmark, Check, Trash2, Plus } from 'lucide-react'
 import {
   saveUserBlueprint,
   useUserBlueprints,
@@ -11,10 +11,9 @@ import {
 import {
   interpolateModifier, multiplierToImprovement, formatImprovementWithWord,
   getStatLabel, getStatDescription,
-  resourceColor, resourceBgColor, resourceBorderColor,
   computeActualValue, formatActualValue, computeDPS,
-  isItemSlot,
 } from './craftingUtils'
+import QualitySlider from './QualitySlider'
 
 function Tooltip({ text, children, position = 'top' }) {
   const posStyles = position === 'right'
@@ -32,113 +31,6 @@ function Tooltip({ text, children, position = 'top' }) {
         <span className={arrowStyles} />
       </span>
     </span>
-  )
-}
-
-const SNAP_POINTS = [0, 250, 500, 750, 1000]
-const SNAP_THRESHOLD = 15
-
-function snapValue(raw) {
-  for (const sp of SNAP_POINTS) {
-    if (Math.abs(raw - sp) <= SNAP_THRESHOLD) return sp
-  }
-  return raw
-}
-
-function QualitySlider({ slot, value, onChange }) {
-  const [textValue, setTextValue] = useState(String(value))
-  const [editing, setEditing] = useState(false)
-  const pct = (value / 1000) * 100
-
-  // Keep text in sync when value changes externally (e.g. slider drag)
-  React.useEffect(() => {
-    if (!editing) setTextValue(String(value))
-  }, [value, editing])
-
-  const commitText = () => {
-    setEditing(false)
-    const parsed = parseInt(textValue)
-    if (!isNaN(parsed)) {
-      onChange(Math.max(0, Math.min(1000, parsed)))
-    } else {
-      setTextValue(String(value))
-    }
-  }
-
-  return (
-    <div className="bg-white/[0.02] border border-white/[0.05] rounded-lg p-3">
-      <div className="flex items-center justify-between mb-1.5">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-gray-300">{slot.name}</span>
-          {isItemSlot(slot) ? (
-            <span
-              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium border bg-violet-500/15 text-violet-300 border-violet-500/30"
-              title="This slot requires a specific harvestable mineral, not a generic resource. Quality slider works the same way."
-            >
-              <Gem className="w-2.5 h-2.5" />
-              {slot.resource_name}
-              <span className="ml-1 px-1 py-px rounded text-[8px] font-bold tracking-wider bg-violet-500/20 text-violet-200">MINERAL</span>
-            </span>
-          ) : (
-            <span
-              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
-              style={{
-                backgroundColor: resourceBgColor(slot.resource_name),
-                borderColor: resourceBorderColor(slot.resource_name),
-                color: resourceColor(slot.resource_name),
-              }}
-            >
-              <Gem className="w-2.5 h-2.5" />
-              {slot.resource_name}
-            </span>
-          )}
-        </div>
-        <input
-          type="text"
-          inputMode="numeric"
-          value={editing ? textValue : String(value)}
-          onChange={e => { setTextValue(e.target.value); setEditing(true) }}
-          onFocus={e => { setEditing(true); e.target.select() }}
-          onBlur={commitText}
-          onKeyDown={e => { if (e.key === 'Enter') { e.target.blur() } }}
-          className="w-12 text-right text-xs font-mono text-sc-accent bg-transparent border border-transparent hover:border-white/[0.08] focus:border-sc-accent/40 focus:bg-white/[0.03] rounded px-1 py-0.5 outline-none transition-all"
-        />
-      </div>
-      <div className="relative">
-        <div className="h-1.5 rounded-full overflow-hidden" style={{ background: 'linear-gradient(to right, #ef4444, #f59e0b, #22c55e)' }}>
-          <div className="h-full bg-transparent" />
-        </div>
-        <input
-          type="range"
-          min={0}
-          max={1000}
-          value={value}
-          onChange={e => onChange(snapValue(parseInt(e.target.value)))}
-          className="absolute inset-0 w-full h-1.5 opacity-0 cursor-pointer"
-          style={{ top: '0' }}
-        />
-        <div
-          className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white border-2 border-sc-accent shadow-[0_0_6px_rgba(34,211,238,0.5)] pointer-events-none transition-all duration-100"
-          style={{ left: `calc(${pct}% - 6px)` }}
-        />
-        {/* Snap point markers */}
-        {SNAP_POINTS.slice(1, -1).map(sp => (
-          <button
-            key={sp}
-            onClick={() => onChange(sp)}
-            className={`absolute top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full transition-all cursor-pointer ${
-              value === sp ? 'bg-sc-accent scale-125' : 'bg-gray-600 hover:bg-gray-400'
-            }`}
-            style={{ left: `calc(${(sp / 1000) * 100}% - 3px)` }}
-            title={`Q${sp}`}
-          />
-        ))}
-      </div>
-      <div className="flex justify-between mt-1 text-[10px] text-gray-600">
-        <button onClick={() => onChange(0)} className="hover:text-gray-400 cursor-pointer transition-colors">0</button>
-        <button onClick={() => onChange(1000)} className="hover:text-gray-400 cursor-pointer transition-colors">1000</button>
-      </div>
-    </div>
   )
 }
 

--- a/frontend/src/pages/Crafting/QualitySlider.jsx
+++ b/frontend/src/pages/Crafting/QualitySlider.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react'
+import { Gem } from 'lucide-react'
+import { resourceColor, resourceBgColor, resourceBorderColor, isItemSlot } from './craftingUtils'
+
+export const SNAP_POINTS = [0, 250, 500, 750, 1000]
+const SNAP_THRESHOLD = 15
+
+export function snapValue(raw) {
+  for (const sp of SNAP_POINTS) {
+    if (Math.abs(raw - sp) <= SNAP_THRESHOLD) return sp
+  }
+  return raw
+}
+
+export default function QualitySlider({ slot, value, onChange }) {
+  const [textValue, setTextValue] = useState(String(value))
+  const [editing, setEditing] = useState(false)
+  const pct = (value / 1000) * 100
+
+  // Keep text in sync when value changes externally (e.g. slider drag)
+  React.useEffect(() => {
+    if (!editing) setTextValue(String(value))
+  }, [value, editing])
+
+  const commitText = () => {
+    setEditing(false)
+    const parsed = parseInt(textValue)
+    if (!isNaN(parsed)) {
+      onChange(Math.max(0, Math.min(1000, parsed)))
+    } else {
+      setTextValue(String(value))
+    }
+  }
+
+  return (
+    <div className="bg-white/[0.02] border border-white/[0.05] rounded-lg p-3">
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-gray-300">{slot.name}</span>
+          {isItemSlot(slot) ? (
+            <span
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium border bg-violet-500/15 text-violet-300 border-violet-500/30"
+              title="This slot requires a specific harvestable mineral, not a generic resource. Quality slider works the same way."
+            >
+              <Gem className="w-2.5 h-2.5" />
+              {slot.resource_name}
+              <span className="ml-1 px-1 py-px rounded text-[8px] font-bold tracking-wider bg-violet-500/20 text-violet-200">MINERAL</span>
+            </span>
+          ) : (
+            <span
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium border"
+              style={{
+                backgroundColor: resourceBgColor(slot.resource_name),
+                borderColor: resourceBorderColor(slot.resource_name),
+                color: resourceColor(slot.resource_name),
+              }}
+            >
+              <Gem className="w-2.5 h-2.5" />
+              {slot.resource_name}
+            </span>
+          )}
+        </div>
+        <input
+          type="text"
+          inputMode="numeric"
+          value={editing ? textValue : String(value)}
+          onChange={e => { setTextValue(e.target.value); setEditing(true) }}
+          onFocus={e => { setEditing(true); e.target.select() }}
+          onBlur={commitText}
+          onKeyDown={e => { if (e.key === 'Enter') { e.target.blur() } }}
+          className="w-12 text-right text-xs font-mono text-sc-accent bg-transparent border border-transparent hover:border-white/[0.08] focus:border-sc-accent/40 focus:bg-white/[0.03] rounded px-1 py-0.5 outline-none transition-all"
+        />
+      </div>
+      <div className="relative">
+        <div className="h-1.5 rounded-full overflow-hidden" style={{ background: 'linear-gradient(to right, #ef4444, #f59e0b, #22c55e)' }}>
+          <div className="h-full bg-transparent" />
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          value={value}
+          onChange={e => onChange(snapValue(parseInt(e.target.value)))}
+          className="absolute inset-0 w-full h-1.5 opacity-0 cursor-pointer"
+          style={{ top: '0' }}
+        />
+        <div
+          className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white border-2 border-sc-accent shadow-[0_0_6px_rgba(34,211,238,0.5)] pointer-events-none transition-all duration-100"
+          style={{ left: `calc(${pct}% - 6px)` }}
+        />
+        {/* Snap point markers */}
+        {SNAP_POINTS.slice(1, -1).map(sp => (
+          <button
+            key={sp}
+            onClick={() => onChange(sp)}
+            className={`absolute top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full transition-all cursor-pointer ${
+              value === sp ? 'bg-sc-accent scale-125' : 'bg-gray-600 hover:bg-gray-400'
+            }`}
+            style={{ left: `calc(${(sp / 1000) * 100}% - 3px)` }}
+            title={`Q${sp}`}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between mt-1 text-[10px] text-gray-600">
+        <button onClick={() => onChange(0)} className="hover:text-gray-400 cursor-pointer transition-colors">0</button>
+        <button onClick={() => onChange(1000)} className="hover:text-gray-400 cursor-pointer transition-colors">1000</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Crafting/QualitySlider.test.jsx
+++ b/frontend/src/pages/Crafting/QualitySlider.test.jsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import QualitySlider, { snapValue } from './QualitySlider'
+
+describe('QualitySlider', () => {
+  it('snaps near a snap point', () => {
+    expect(snapValue(248)).toBe(250)
+    expect(snapValue(500)).toBe(500)
+    expect(snapValue(123)).toBe(123)
+  })
+  it('renders the slot name + resource and reports changes', () => {
+    const onChange = vi.fn()
+    render(<QualitySlider slot={{ name: 'Barrel', resource_name: 'Iron', slot_type: 'resource' }} value={500} onChange={onChange} />)
+    expect(screen.getByText('Barrel')).toBeInTheDocument()
+    expect(screen.getByText('Iron')).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '800' } })
+    expect(onChange).toHaveBeenCalledWith(800)
+  })
+})

--- a/frontend/src/pages/FpsLoadout/StatsPanel.jsx
+++ b/frontend/src/pages/FpsLoadout/StatsPanel.jsx
@@ -1,0 +1,56 @@
+// frontend/src/pages/FpsLoadout/StatsPanel.jsx
+import React from 'react'
+
+function pctDelta(base, build) {
+  if (base == null || build == null || base === 0) return null
+  return ((build / base) - 1) * 100
+}
+const fmt = (v, d) => (v == null ? '—' : Number(v).toFixed(d))
+
+function Row({ label, sub, base, build, deltaPct, staticValue }) {
+  // Stats crafting/attachments don't affect render once (no base→build split).
+  if (staticValue != null) {
+    return (
+      <div className="grid grid-cols-[1fr_auto] items-center gap-3 py-2 border-b border-white/[0.06] text-sm">
+        <div className="text-gray-300">{label}{sub && <span className="block text-[10px] uppercase tracking-wide text-gray-600">{sub}</span>}</div>
+        <div className="text-right text-gray-400 font-mono tabular-nums">{staticValue}</div>
+      </div>
+    )
+  }
+  const cls = deltaPct == null || Math.abs(deltaPct) < 0.05 ? 'text-gray-500'
+    : deltaPct > 0 ? 'text-emerald-400' : 'text-red-400'
+  return (
+    <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 py-2 border-b border-white/[0.06] text-sm">
+      <div className="text-gray-300">{label}{sub && <span className="block text-[10px] uppercase tracking-wide text-gray-600">{sub}</span>}</div>
+      <div className="text-right text-gray-500 font-mono tabular-nums">{base}</div>
+      <div className="text-right font-mono tabular-nums text-sc-accent">{build}</div>
+      <div className={`text-right text-xs font-mono tabular-nums ${cls}`}>
+        {deltaPct == null ? '—' : `${deltaPct > 0 ? '+' : ''}${deltaPct.toFixed(1)}%`}
+      </div>
+    </div>
+  )
+}
+
+export default function StatsPanel({ baseStats, stats }) {
+  if (!baseStats || !stats) return null
+  return (
+    <div>
+      {baseStats.damage != null && (
+        <Row label="Damage" sub="per shot" base={fmt(baseStats.damage, 1)} build={fmt(stats.damage, 1)} deltaPct={pctDelta(baseStats.damage, stats.damage)} />
+      )}
+      {baseStats.rounds_per_minute != null && (
+        <Row label="Fire Rate" sub="rpm" base={fmt(baseStats.rounds_per_minute, 0)} build={fmt(stats.rpm, 0)} deltaPct={pctDelta(baseStats.rounds_per_minute, stats.rpm)} />
+      )}
+      {baseStats.dps != null && (
+        <Row label="DPS" sub="derived" base={fmt(baseStats.dps, 1)} build={fmt(stats.dps, 1)} deltaPct={pctDelta(baseStats.dps, stats.dps)} />
+      )}
+      <Row label="Recoil Kick" sub="×curve" base="×1.00" build={`×${fmt(stats.recoil, 2)}`} deltaPct={null} />
+      {baseStats.effective_range != null && (
+        <Row label="Effective Range" staticValue={`${fmt(baseStats.effective_range, 0)} m`} />
+      )}
+      {baseStats.ammo_capacity != null && (
+        <Row label="Magazine" staticValue={`${fmt(baseStats.ammo_capacity, 0)}`} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/FpsLoadout/StatsPanel.test.jsx
+++ b/frontend/src/pages/FpsLoadout/StatsPanel.test.jsx
@@ -1,0 +1,24 @@
+// frontend/src/pages/FpsLoadout/StatsPanel.test.jsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import StatsPanel from './StatsPanel'
+
+const BASE = { damage: 13, rounds_per_minute: 950, dps: 205.8, effective_range: 20, ammo_capacity: 25 }
+const STATS = { damage: 13.62, rpm: 818, dps: 185.4, recoil: 0.864, multipliers: {} }
+
+describe('StatsPanel', () => {
+  it('shows base → build for damage / fire rate / dps', () => {
+    render(<StatsPanel baseStats={BASE} stats={STATS} />)
+    expect(screen.getByText('Damage')).toBeInTheDocument()
+    expect(screen.getByText('13.6')).toBeInTheDocument()       // build damage, 1 dp
+    expect(screen.getByText('818')).toBeInTheDocument()        // build rpm, 0 dp
+    expect(screen.getByText(/Fire Rate/)).toBeInTheDocument()
+    expect(screen.getByText('DPS')).toBeInTheDocument()
+  })
+  it('shows recoil as a multiplier and unaffected stats as fixed', () => {
+    render(<StatsPanel baseStats={BASE} stats={STATS} />)
+    expect(screen.getByText('×0.86')).toBeInTheDocument()      // recoil
+    expect(screen.getByText('20 m')).toBeInTheDocument()       // range, unaffected
+    expect(screen.getByText('25')).toBeInTheDocument()         // magazine
+  })
+})

--- a/frontend/src/pages/FpsLoadout/WeaponBench.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBench.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/FpsLoadout/WeaponBench.jsx
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import QualitySlider from '../Crafting/QualitySlider'
 import StatsPanel from './StatsPanel'
 import { combinedMultipliers, computeBenchStats } from './weaponBenchStats'
@@ -10,6 +10,12 @@ export default function WeaponBench({ blueprint, attachments = [] }) {
   const slots = blueprint?.slots || []
   const [qualities, setQualities] = useState(() => Object.fromEntries(slots.map((_, i) => [i, 500])))
   const [equipped, setEquipped] = useState({}) // { [slotType]: attachmentUuid }
+
+  useEffect(() => {
+    const newSlots = blueprint?.slots || []
+    setQualities(Object.fromEntries(newSlots.map((_, i) => [i, 500])))
+    setEquipped({})
+  }, [blueprint?.name]) // intentional: reset only when the weapon identity changes, not on every slots reference
 
   const equippedList = useMemo(
     () => Object.values(equipped).map((uuid) => attachments.find((a) => a.uuid === uuid)).filter(Boolean),

--- a/frontend/src/pages/FpsLoadout/WeaponBench.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBench.jsx
@@ -1,0 +1,79 @@
+// frontend/src/pages/FpsLoadout/WeaponBench.jsx
+import React, { useMemo, useState } from 'react'
+import QualitySlider from '../Crafting/QualitySlider'
+import StatsPanel from './StatsPanel'
+import { combinedMultipliers, computeBenchStats } from './weaponBenchStats'
+import { isCompatible } from './attachmentCompat'
+import { resolveWeaponIcon } from './weaponIcon'
+
+export default function WeaponBench({ blueprint, attachments = [] }) {
+  const slots = blueprint?.slots || []
+  const [qualities, setQualities] = useState(() => Object.fromEntries(slots.map((_, i) => [i, 500])))
+  const [equipped, setEquipped] = useState({}) // { [slotType]: attachmentUuid }
+
+  const equippedList = useMemo(
+    () => Object.values(equipped).map((uuid) => attachments.find((a) => a.uuid === uuid)).filter(Boolean),
+    [equipped, attachments],
+  )
+
+  const stats = useMemo(() => {
+    if (!blueprint) return null
+    const m = combinedMultipliers(slots, qualities, equippedList)
+    return computeBenchStats(blueprint.base_stats, m)
+  }, [blueprint, slots, qualities, equippedList])
+
+  if (!blueprint) {
+    return <div className="text-center py-12 text-gray-500 text-sm">Select a weapon to begin.</div>
+  }
+
+  const toggle = (att) => setEquipped((prev) => {
+    const next = { ...prev }
+    if (next[att.slot] === att.uuid) delete next[att.slot]
+    else next[att.slot] = att.uuid
+    return next
+  })
+
+  const { url } = resolveWeaponIcon(blueprint) // placeholder name lives in the <h3>, so only the url is used here
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-3">
+        {url
+          ? <img src={url} alt={blueprint.name} className="w-16 h-10 object-contain" />
+          : <span className="w-16 h-10 flex items-center justify-center text-[9px] uppercase tracking-wide text-gray-600 border border-dashed border-white/10 rounded">no icon</span>}
+        <h3 className="text-lg font-semibold text-white">{blueprint.name}</h3>
+      </div>
+
+      <div>
+        <h4 className="text-xs uppercase tracking-wider text-gray-500 mb-2">Crafting Materials</h4>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {slots.map((slot, i) => (
+            <QualitySlider key={i} slot={slot} value={qualities[i] ?? 500}
+              onChange={(v) => setQualities((q) => ({ ...q, [i]: v }))} />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h4 className="text-xs uppercase tracking-wider text-gray-500 mb-2">Attachments</h4>
+        <div className="flex flex-wrap gap-2">
+          {attachments.map((att) => {
+            const ok = isCompatible(blueprint, att)
+            const on = equipped[att.slot] === att.uuid
+            return (
+              <button key={att.uuid} type="button" disabled={!ok} onClick={() => toggle(att)}
+                className={`px-2.5 py-1 text-xs rounded border transition-colors ${
+                  on ? 'border-sc-accent/40 text-sc-accent bg-sc-accent/10'
+                  : ok ? 'border-white/10 text-gray-400 hover:text-white'
+                  : 'border-white/5 text-gray-700 cursor-not-allowed'}`}>
+                {att.name}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <StatsPanel baseStats={blueprint.base_stats} stats={stats} />
+    </div>
+  )
+}

--- a/frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
 import { describe, it, expect } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import WeaponBench from './WeaponBench'
 
 const BLUEPRINT = {
@@ -16,6 +16,14 @@ const BLUEPRINT = {
 const ATTACHMENTS = [
   { uuid: 'stark', name: 'Stark Compensator 1', slot: 'barrel', fire_rate_multiplier: 0.8 },
 ]
+
+const BLUEPRINT_2 = {
+  name: 'P4-AR Rifle',
+  base_stats: { damage: 22, rounds_per_minute: 600, dps: 220, effective_range: 50, ammo_capacity: 30 },
+  slots: [
+    { name: 'Receiver', resource_name: 'Titanium', slot_type: 'resource', modifiers: [] },
+  ],
+}
 
 describe('WeaponBench', () => {
   it('renders the weapon, a slider per material slot, and a stats panel', () => {
@@ -36,5 +44,27 @@ describe('WeaponBench', () => {
   it('shows a placeholder banner when no blueprint', () => {
     render(<WeaponBench blueprint={null} attachments={[]} />)
     expect(screen.getByText(/select a weapon/i)).toBeInTheDocument()
+  })
+
+  it('resets qualities and equipped state when the weapon blueprint changes', () => {
+    // BLUEPRINT has 2 slots; BLUEPRINT_2 has 1 slot.
+    // After rerender with BLUEPRINT_2 the old equipped attachments must be cleared ({}).
+    // We verify this by equipping Stark Compensator on BLUEPRINT (rpm drops from 950→760),
+    // then switching to BLUEPRINT_2 and asserting its base rpm (600) is the build value —
+    // if equipped was NOT reset, Stark's ×0.8 would make it 480 instead.
+    const { rerender } = render(<WeaponBench blueprint={BLUEPRINT} attachments={ATTACHMENTS} />)
+    // Equip the attachment on the first weapon; build rpm drops to 760
+    fireEvent.click(screen.getByRole('button', { name: /Stark Compensator 1/ }))
+    expect(screen.getByText('760')).toBeInTheDocument()
+
+    // Switch to a different weapon (2 slots → 1 slot)
+    rerender(<WeaponBench blueprint={BLUEPRINT_2} attachments={ATTACHMENTS} />)
+
+    // The slider count must match the new weapon's slot count
+    expect(screen.getAllByRole('slider')).toHaveLength(1)
+
+    // If equipped was NOT reset, Stark Compensator would still be active →
+    // build rpm = 600 × 0.8 = 480. A correct reset means no 480 in the DOM.
+    expect(screen.queryByText('480')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
@@ -1,0 +1,40 @@
+// frontend/src/pages/FpsLoadout/WeaponBench.test.jsx
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import WeaponBench from './WeaponBench'
+
+const BLUEPRINT = {
+  name: 'LH86 Pistol',
+  base_stats: { damage: 13, rounds_per_minute: 950, dps: 205.8, effective_range: 20, ammo_capacity: 25 },
+  slots: [
+    { name: 'Frame', resource_name: 'Aluminum', slot_type: 'resource', modifiers: [
+      { key: 'weapon_recoil_kick', start_quality: 0, end_quality: 1000, modifier_at_start: 1.2, modifier_at_end: 0.8 } ] },
+    { name: 'Barrel', resource_name: 'Iron', slot_type: 'resource', modifiers: [
+      { key: 'weapon_firerate', start_quality: 0, end_quality: 1000, modifier_at_start: 0.88, modifier_at_end: 1.12 } ] },
+  ],
+}
+const ATTACHMENTS = [
+  { uuid: 'stark', name: 'Stark Compensator 1', slot: 'barrel', fire_rate_multiplier: 0.8 },
+]
+
+describe('WeaponBench', () => {
+  it('renders the weapon, a slider per material slot, and a stats panel', () => {
+    render(<WeaponBench blueprint={BLUEPRINT} attachments={ATTACHMENTS} />)
+    expect(screen.getByText('LH86 Pistol')).toBeInTheDocument()
+    expect(screen.getAllByRole('slider')).toHaveLength(2)      // Frame + Barrel
+    expect(screen.getByText('Damage')).toBeInTheDocument()
+  })
+
+  it('recomputes fire rate when an attachment is equipped', () => {
+    render(<WeaponBench blueprint={BLUEPRINT} attachments={ATTACHMENTS} />)
+    // At default Q500 the firerate curve interpolates to ×1.0, so build rpm = base (950).
+    // Equipping the Stark Compensator (−20%) drops build rpm to 760 (unique in the DOM).
+    fireEvent.click(screen.getByRole('button', { name: /Stark Compensator 1/ }))
+    expect(screen.getByText('760')).toBeInTheDocument()
+  })
+
+  it('shows a placeholder banner when no blueprint', () => {
+    render(<WeaponBench blueprint={null} attachments={[]} />)
+    expect(screen.getByText(/select a weapon/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/FpsLoadout/WeaponBenchContainer.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBenchContainer.jsx
@@ -1,0 +1,38 @@
+// frontend/src/pages/FpsLoadout/WeaponBenchContainer.jsx
+import React, { useMemo, useState } from 'react'
+import { useCrafting, useFpsGear } from '../../hooks/useAPI'
+import WeaponBench from './WeaponBench'
+
+const SLOT_FROM_SUBTYPE = { barrel: 'barrel', optic: 'optic', scope: 'optic', underbarrel: 'underbarrel' }
+
+export default function WeaponBenchContainer() {
+  const crafting = useCrafting()
+  const gear = useFpsGear()
+  const [selected, setSelected] = useState(0)
+
+  const weapons = useMemo(
+    () => (crafting.data?.blueprints || []).filter((b) => b.type === 'weapons' && (b.slots?.length > 0)),
+    [crafting.data],
+  )
+  const attachments = useMemo(
+    () => (gear.data?.items || [])
+      .filter((i) => i.category === 'Weapons' && i.sub_category === 'Attachments')
+      .map((i) => ({ ...i, uuid: i.uuid || String(i.id), slot: SLOT_FROM_SUBTYPE[i.sub_type] || 'barrel' })),
+    [gear.data],
+  )
+
+  if (crafting.loading) return <div className="text-gray-500 text-sm p-4">Loading…</div>
+  if (!weapons.length) return <div className="text-gray-500 text-sm p-4">No craftable weapons available.</div>
+
+  const blueprint = weapons[selected] || weapons[0]
+  return (
+    <div className="space-y-4">
+      <select role="combobox" aria-label="Select weapon" value={selected}
+        onChange={(e) => setSelected(Number(e.target.value))}
+        className="bg-white/[0.04] border border-white/10 rounded px-2.5 py-1.5 text-sm text-gray-200">
+        {weapons.map((w, i) => <option key={w.name + i} value={i}>{w.name}</option>)}
+      </select>
+      <WeaponBench blueprint={blueprint} attachments={attachments} />
+    </div>
+  )
+}

--- a/frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 vi.mock('../../hooks/useAPI', () => ({
   useCrafting: () => ({ data: {

--- a/frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
+++ b/frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
@@ -1,0 +1,29 @@
+// frontend/src/pages/FpsLoadout/WeaponBenchContainer.test.jsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('../../hooks/useAPI', () => ({
+  useCrafting: () => ({ data: {
+    blueprints: [{
+      name: 'LH86 Pistol', type: 'weapons', sub_type: 'pistol',
+      base_stats: { damage: 13, rounds_per_minute: 950, dps: 205.8 },
+      slots: [{ name: 'Barrel', resource_name: 'Iron', slot_type: 'resource', modifiers: [
+        { key: 'weapon_firerate', start_quality: 0, end_quality: 1000, modifier_at_start: 0.88, modifier_at_end: 1.12 } ] }],
+    }],
+  }, loading: false, error: null }),
+  useFpsGear: () => ({ data: { items: [
+    { id: 1, name: 'Stark Compensator 1', category: 'Weapons', sub_category: 'Attachments', sub_type: 'barrel', fire_rate_multiplier: 0.8, uuid: 'stark' },
+  ] }, loading: false, error: null }),
+}))
+
+import WeaponBenchContainer from './WeaponBenchContainer'
+
+describe('WeaponBenchContainer', () => {
+  it('lists weapon blueprints and renders the bench for the chosen one', () => {
+    render(<WeaponBenchContainer />)
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    // 'LH86 Pistol' renders twice (the <option> and the bench <h3>), so assert the option by role.
+    expect(screen.getByRole('option', { name: 'LH86 Pistol' })).toBeInTheDocument()
+    expect(screen.getByText('Damage')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/FpsLoadout/attachmentCompat.js
+++ b/frontend/src/pages/FpsLoadout/attachmentCompat.js
@@ -1,0 +1,11 @@
+// Pluggable seam: permissive until port data is populated (plan B), then enforces the port rule.
+export function isCompatible(weapon, attachment) {
+  const ports = weapon?.attachment_ports
+  const attType = attachment?.attach_port_type
+  const attSize = attachment?.attach_size
+  // No port data on either side yet → allow (current state).
+  if (!Array.isArray(ports) || ports.length === 0 || attType == null || attSize == null) return true
+  return ports.some(
+    (p) => p.port_type === attType && attSize >= (p.size_min ?? 0) && attSize <= (p.size_max ?? Infinity),
+  )
+}

--- a/frontend/src/pages/FpsLoadout/attachmentCompat.test.js
+++ b/frontend/src/pages/FpsLoadout/attachmentCompat.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { isCompatible } from './attachmentCompat'
+
+describe('isCompatible', () => {
+  it('is permissive when no port data is present (current state)', () => {
+    expect(isCompatible({ name: 'LH86' }, { name: 'Scope' })).toBe(true)
+  })
+  it('enforces port type + size when port data exists', () => {
+    const weapon = { attachment_ports: [{ port_type: 'optic', size_min: 1, size_max: 2 }] }
+    expect(isCompatible(weapon, { attach_port_type: 'optic', attach_size: 1 })).toBe(true)
+    expect(isCompatible(weapon, { attach_port_type: 'optic', attach_size: 3 })).toBe(false)  // too big
+    expect(isCompatible(weapon, { attach_port_type: 'barrel', attach_size: 1 })).toBe(false) // wrong type
+  })
+})

--- a/frontend/src/pages/FpsLoadout/index.jsx
+++ b/frontend/src/pages/FpsLoadout/index.jsx
@@ -77,23 +77,6 @@ function EquipSlot({ icon, size = '2.4vw', badge = null, children }) {
   )
 }
 
-function PaperdollSlot({ icon, style, small = false }) {
-  const cls = small ? 'w-[4vmin] h-[4vmin]' : 'w-[5.5vmin] h-[5.5vmin]'
-  return (
-    <div
-      className={`${cls} flex items-center justify-center cursor-pointer rounded-full`}
-      style={{
-        border: '1px solid rgba(0,200,230,0.25)',
-        background: 'rgba(0,18,28,0.4)',
-        position: small ? 'static' : 'absolute',
-        ...style,
-      }}
-    >
-      <Ico src={icon} size={small ? '1.6vmin' : '2.5vmin'} />
-    </div>
-  )
-}
-
 function EquipmentPanel({ equipTab, setEquipTab }) {
   return (
     <div className="flex flex-col h-full">
@@ -173,46 +156,6 @@ function EquipmentPanel({ equipTab, setEquipTab }) {
             )}
           </div>
         </div>
-      </div>
-    </div>
-  )
-}
-
-function Paperdoll() {
-  return (
-    <div className="relative w-full h-full">
-      {/* Right column — armor/clothing slots, evenly spaced, centered vertically */}
-      <PaperdollSlot icon="icon_common_helmet.svg" style={{ top: '15%', right: '10%' }} />
-      <PaperdollSlot icon="icon_common_glasses.svg" style={{ top: '29%', right: '10%' }} />
-      <PaperdollSlot icon="PIT_Looting_Core_Icon.svg" style={{ top: '43%', right: '10%' }} />
-      <PaperdollSlot icon="icon_common_arms.svg" style={{ top: '57%', right: '10%' }} />
-      <PaperdollSlot icon="PIT_Looting_Legs_Icon.svg" style={{ top: '71%', right: '10%' }} />
-      <PaperdollSlot icon="icon_common_shoe.svg" style={{ top: '85%', right: '10%' }} />
-
-      {/* Left — Throwables row (aligns with glasses @ 29%) */}
-      <div className="absolute flex gap-[0.3vw]" style={{ top: '29%', left: '6%' }}>
-        {[0,1,2,3].map(i => <PaperdollSlot key={i} icon="icon_common_grenade.svg" small />)}
-      </div>
-
-      {/* Left — Backpack (aligns with core @ 43%) */}
-      <PaperdollSlot icon="PIT_Looting_Backpack_Icon.svg" style={{ top: '43%', left: '6%' }} />
-
-      {/* Left — Magazines 2 rows, midpoint aligns with arms @ 57% */}
-      <div className="absolute flex gap-[0.3vw]" style={{ top: '54%', left: '6%' }}>
-        {[0,1,2,3].map(i => <PaperdollSlot key={i} icon="icon_common_magazine.svg" small />)}
-      </div>
-      <div className="absolute flex gap-[0.3vw]" style={{ top: '60%', left: '6%' }}>
-        {[0,1,2,3].map(i => <PaperdollSlot key={i} icon="icon_common_magazine.svg" small />)}
-      </div>
-
-      {/* Left — Consumables (aligns with legs @ 71%) */}
-      <div className="absolute flex gap-[0.3vw]" style={{ top: '71%', left: '6%' }}>
-        {[0,1,2,3].map(i => <PaperdollSlot key={i} icon="icon_common_consumable.svg" small />)}
-      </div>
-
-      {/* Center label */}
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[30px] tracking-[0.3em] uppercase pointer-events-none" style={{ color: 'rgba(192,246,254,0.12)' }}>
-        LOADOUT
       </div>
     </div>
   )

--- a/frontend/src/pages/FpsLoadout/index.jsx
+++ b/frontend/src/pages/FpsLoadout/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import { useFpsGear } from '../../hooks/useAPI'
+import WeaponBenchContainer from './WeaponBenchContainer'
 
 const ICON = (name) => `/inventory-assets/${name}`
 
@@ -490,12 +491,12 @@ export default function FpsLoadout() {
             <EquipmentPanel equipTab={equipTab} setEquipTab={setEquipTab} />
           </div>
 
-          {/* Center — Paperdoll */}
+          {/* Center — Weapon Bench */}
           <div
             className="absolute z-[5]"
             style={{ left: '26.5625%', right: '26.5625%', top: 0, height: '100%' }}
           >
-            <Paperdoll />
+            <div className="h-full overflow-y-auto p-4"><WeaponBenchContainer /></div>
           </div>
 
           {/* Right panel — Gear Browser */}

--- a/frontend/src/pages/FpsLoadout/weaponBenchStats.js
+++ b/frontend/src/pages/FpsLoadout/weaponBenchStats.js
@@ -1,0 +1,46 @@
+import { interpolateModifier, computeDPS } from '../Crafting/craftingUtils'
+
+const num = (v) => (typeof v === 'number' && !Number.isNaN(v) ? v : 1)
+
+// Per crafting-property multiplier = product over every material slot that affects it.
+export function craftedMultipliers(slots, qualities) {
+  const out = new Map()
+  ;(slots || []).forEach((slot, i) => {
+    for (const mod of slot?.modifiers || []) {
+      const key = mod.key || mod.name
+      const prev = out.get(key) ?? 1
+      out.set(key, prev * interpolateModifier(mod, (qualities && qualities[i]) || 0))
+    }
+  })
+  return out
+}
+
+// Loot-only attachments today → fixed multipliers. qualityConfig reserved for future craftable attachments.
+export function resolveAttachmentMultipliers(attachment /*, qualityConfig */) {
+  if (!attachment) return {}
+  return {
+    weapon_damage: num(attachment.damage_multiplier),
+    weapon_firerate: num(attachment.fire_rate_multiplier),
+    projectile_speed: num(attachment.projectile_speed_multiplier),
+    heat: num(attachment.heat_generation_multiplier),
+  }
+}
+
+export function combinedMultipliers(slots, qualities, attachments) {
+  const result = {}
+  for (const [k, v] of craftedMultipliers(slots, qualities)) result[k] = v
+  for (const att of attachments || []) {
+    for (const [k, v] of Object.entries(resolveAttachmentMultipliers(att))) {
+      result[k] = (result[k] ?? 1) * v
+    }
+  }
+  return result
+}
+
+export function computeBenchStats(baseStats, combined) {
+  const m = combined || {}
+  const damage = baseStats?.damage != null ? baseStats.damage * (m.weapon_damage ?? 1) : null
+  const rpm = baseStats?.rounds_per_minute != null ? baseStats.rounds_per_minute * (m.weapon_firerate ?? 1) : null
+  const dps = damage != null && rpm != null ? computeDPS(damage, rpm) : null
+  return { damage, rpm, dps, recoil: m.weapon_recoil_kick ?? 1, multipliers: m }
+}

--- a/frontend/src/pages/FpsLoadout/weaponBenchStats.test.js
+++ b/frontend/src/pages/FpsLoadout/weaponBenchStats.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  craftedMultipliers, resolveAttachmentMultipliers, combinedMultipliers, computeBenchStats,
+} from './weaponBenchStats'
+
+// Real Gmni Pistol Ballistic 01 (= base LH86) recipe.
+const SLOTS = [
+  { name: 'Frame', resource_name: 'Aluminum', modifiers: [
+    { key: 'weapon_recoil_kick', start_quality: 0, end_quality: 1000, modifier_at_start: 1.2, modifier_at_end: 0.8 },
+  ] },
+  { name: 'Grip', resource_name: 'Hephaestanite', modifiers: [
+    { key: 'weapon_recoil_kick', start_quality: 0, end_quality: 1000, modifier_at_start: 1.2, modifier_at_end: 0.8 },
+  ] },
+  { name: 'Barrel', resource_name: 'Iron', modifiers: [
+    { key: 'weapon_damage',   start_quality: 0, end_quality: 1000, modifier_at_start: 0.925, modifier_at_end: 1.075 },
+    { key: 'weapon_firerate', start_quality: 0, end_quality: 1000, modifier_at_start: 0.88,  modifier_at_end: 1.12 },
+  ] },
+]
+const BASE = { damage: 13, rounds_per_minute: 950, dps: 205.8 }
+const STARK = { fire_rate_multiplier: 0.8, damage_multiplier: null } // -20% fire rate
+
+describe('craftedMultipliers', () => {
+  it('stacks recoil across Frame+Grip and applies Barrel to damage/firerate', () => {
+    const q = { 0: 750, 1: 600, 2: 820 }
+    const m = craftedMultipliers(SLOTS, q)
+    // Frame @750: 1.2 + (0.8-1.2)*0.75 = 0.90 ; Grip @600: 1.2 + (-0.4)*0.6 = 0.96 ; product 0.864
+    expect(m.get('weapon_recoil_kick')).toBeCloseTo(0.864, 3)
+    // Barrel @820 damage: 0.925 + 0.15*0.82 = 1.048
+    expect(m.get('weapon_damage')).toBeCloseTo(1.048, 3)
+    // Barrel @820 firerate: 0.88 + 0.24*0.82 = 1.0768
+    expect(m.get('weapon_firerate')).toBeCloseTo(1.0768, 4)
+  })
+})
+
+describe('resolveAttachmentMultipliers', () => {
+  it('reads fixed columns and treats null/missing as 1.0', () => {
+    const r = resolveAttachmentMultipliers(STARK)
+    expect(r.weapon_firerate).toBeCloseTo(0.8, 5)
+    expect(r.weapon_damage).toBeCloseTo(1.0, 5)
+  })
+  it('returns empty object for no attachment', () => {
+    expect(resolveAttachmentMultipliers(null)).toEqual({})
+  })
+})
+
+describe('combinedMultipliers + computeBenchStats', () => {
+  it('composes crafting × attachments and derives DPS from modified damage×rpm', () => {
+    const q = { 0: 750, 1: 600, 2: 820 }
+    const combined = combinedMultipliers(SLOTS, q, [STARK])
+    const s = computeBenchStats(BASE, combined)
+    expect(s.damage).toBeCloseTo(13 * 1.048, 2)               // 13.62
+    expect(s.rpm).toBeCloseTo(950 * 1.0768 * 0.8, 1)          // 818.4
+    expect(s.dps).toBeCloseTo((13 * 1.048) * (950 * 1.0768 * 0.8) / 60, 1)
+    expect(s.recoil).toBeCloseTo(0.864, 3)
+  })
+})

--- a/frontend/src/pages/FpsLoadout/weaponBenchUrl.js
+++ b/frontend/src/pages/FpsLoadout/weaponBenchUrl.js
@@ -1,0 +1,19 @@
+// Compact, URL-safe encoding of a bench build (base64 of JSON).
+export function encodeBuild({ weapon = null, qualities = {}, attachments = {} } = {}) {
+  const json = JSON.stringify({ w: weapon, q: qualities, a: attachments })
+  return btoa(unescape(encodeURIComponent(json)))
+}
+
+export function decodeBuild(value) {
+  const empty = { weapon: null, qualities: {}, attachments: {} }
+  if (!value || typeof value !== 'string') return empty
+  try {
+    const json = decodeURIComponent(escape(atob(value)))
+    const o = JSON.parse(json)
+    const qualities = {}
+    for (const [k, v] of Object.entries(o.q || {})) qualities[Number(k)] = v
+    return { weapon: o.w ?? null, qualities, attachments: o.a || {} }
+  } catch {
+    return empty
+  }
+}

--- a/frontend/src/pages/FpsLoadout/weaponBenchUrl.test.js
+++ b/frontend/src/pages/FpsLoadout/weaponBenchUrl.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { encodeBuild, decodeBuild } from './weaponBenchUrl'
+
+describe('weaponBenchUrl', () => {
+  it('round-trips a build', () => {
+    const build = { weapon: 'gmni_pistol_ballistic_01', qualities: { 0: 750, 1: 600, 2: 820 }, attachments: { barrel: 'uuid-stark' } }
+    expect(decodeBuild(encodeBuild(build))).toEqual(build)
+  })
+  it('tolerates malformed input', () => {
+    expect(decodeBuild('not json')).toEqual({ weapon: null, qualities: {}, attachments: {} })
+    expect(decodeBuild('')).toEqual({ weapon: null, qualities: {}, attachments: {} })
+  })
+})

--- a/frontend/src/pages/FpsLoadout/weaponIcon.js
+++ b/frontend/src/pages/FpsLoadout/weaponIcon.js
@@ -1,0 +1,4 @@
+// Real R2 icons land in plan A. Until then, url is null and the UI shows placeholder text.
+export function resolveWeaponIcon(weapon) {
+  return { url: weapon?.icon_url || null, placeholder: weapon?.name || 'Weapon' }
+}

--- a/frontend/src/pages/FpsLoadout/weaponIcon.test.js
+++ b/frontend/src/pages/FpsLoadout/weaponIcon.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWeaponIcon } from './weaponIcon'
+
+describe('resolveWeaponIcon', () => {
+  it('returns the real icon url when present', () => {
+    expect(resolveWeaponIcon({ name: 'LH86 Pistol', icon_url: 'https://r2/lh86.webp' }))
+      .toEqual({ url: 'https://r2/lh86.webp', placeholder: 'LH86 Pistol' })
+  })
+  it('falls back to the weapon name as placeholder text when no icon', () => {
+    expect(resolveWeaponIcon({ name: 'A03 Sniper Rifle' }))
+      .toEqual({ url: null, placeholder: 'A03 Sniper Rifle' })
+  })
+  it('tolerates a missing weapon', () => {
+    expect(resolveWeaponIcon(null)).toEqual({ url: null, placeholder: 'Weapon' })
+  })
+})


### PR DESCRIPTION
## What

The interactive **core** of the FPS weapon bench (issue #200), inside the existing (feature-flagged) FPS Loadout page. Pick a craftable weapon, set its per-material crafting quality, add attachments, and see live composed stats — `base × Π(crafting-quality curves) × Π(attachment multipliers)`, DPS derived.

## Included

- **Pure, tested modules** (`frontend/src/pages/FpsLoadout/`): `weaponBenchStats` (stat engine, golden-tested against the real Gemini-pistol recipe), `attachmentCompat` (permissive compatibility seam, port-rule ready), `weaponBenchUrl` (shareable build encode/decode), `weaponIcon` (placeholder text until real icons).
- **`QualitySlider`** extracted to `Crafting/` and shared (Quality Sim unchanged).
- **`StatsPanel`** (base→build readout) + **`WeaponBench`** (crafting sliders + attachments + live stats; state resets when the weapon changes) + **`WeaponBenchContainer`** wired into the page. Dead `Paperdoll` mockup code removed.

## Tests

Full frontend build green; **438 frontend tests pass** (53 files).

## Scope / deferred (separate plans)

- **D2:** drag-and-drop equip, the saved-crafted-weapon palette, and the "preview ≠ your crafted weapon" warning.
- **C:** `/api/gamedata/weapon-bench` endpoint + `user_weapon_builds` persistence.
- **B:** port-based attachment compatibility data.
- **A:** real per-weapon icons extracted from the p4k.

## Known follow-up (Plan C)

Attachments are sourced from `/fps-gear` as a stopgap; that endpoint emits attachments under `category='Utility'` and omits the multiplier columns, so **attachments are inert until Plan C ships the proper endpoint**. Documented in the design spec. Moot in prod — the page is behind the `fpsLoadout` flag (off in production).