### PR TITLE
fix(localization): resolve item + commodity keys against CIG's real conventions

### DIFF
--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -215,6 +215,19 @@ function resolveKey(candidate: string, validKeys?: Map<string, string>): string 
 }
 
 /**
+ * Ordered global.ini key candidates for an item.
+ *
+ * CIG writes item labels under two conventions, and which one an item uses is
+ * not derivable from anything we store:
+ *   item_Name<class>   — weapons, most vehicle components
+ *   item_Name_<class>  — armour, helmets (note the underscore)
+ * The bare form comes first so existing matches keep their exact behaviour.
+ */
+function itemKeyCandidates(className: string): string[] {
+  return [`item_Name${className}`, `item_Name_${className}`];
+}
+
+/**
  * Generate item label overrides. Only produces overrides for keys that
  * exist in validKeys (the actual global.ini key set). This prevents
  * phantom keys from colliding with unrelated entries.
@@ -227,13 +240,34 @@ export function generateItemLabels(
   const overrides: LabelOverride[] = [];
   for (const row of rows) {
     if (!row.className) continue;
-    const key = resolveKey(`item_Name${row.className}`, validKeys);
+    const key = itemKeyCandidates(row.className)
+      .map((c) => resolveKey(c, validKeys))
+      .find(Boolean);
     if (!key) continue;
     const tag = buildDetailTag(row, catFormat.fields);
     overrides.push({
       key,
       value: formatLabel(row.name, tag, catFormat.format),
       original: row.name,
+    });
+
+    // The game ships a second, shorter string for many items
+    // (item_Name<class>_short — 715 of them in the 4.9 base) used in compact UI.
+    // Only the base knows that short text, so tag it at merge time via a
+    // sentinel rather than reusing our long name. Requires validKeys: without
+    // the real key set we cannot know a _short key exists, and inventing one
+    // would add a phantom key.
+    if (!validKeys || !tag) continue;
+    // Derive the short key from the convention that actually resolved above,
+    // so the two can never diverge.
+    const shortKey = resolveKey(`${key}_short`, validKeys);
+    if (!shortKey) continue;
+    overrides.push({
+      key: shortKey,
+      value:
+        catFormat.format === "prefix"
+          ? `${BP_PREPEND_SENTINEL}[${tag}] `
+          : `${BP_APPEND_SENTINEL} [${tag}]`,
     });
   }
   return overrides;
@@ -243,6 +277,63 @@ export function generateItemLabels(
 // Enhancements — server-generated overrides from our own data
 // ---------------------------------------------------------------------------
 
+/** A trailing "(Raw)"/"(R)" marker on a commodity's display name. */
+const RAW_SUFFIX = /\(\s*(?:raw|r)\s*\)\s*$/i;
+
+/** Normalise a display name into a global.ini key token (lowercase alphanumerics). */
+function keyToken(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Ordered global.ini key candidates for a commodity.
+ *
+ * `trade_commodities.class_name` is the p4k entity stem and does NOT always
+ * match the game's own key. Real 4.9 cases:
+ *   class "quantanium"              -> items_commodities_quantainium    (class misspelt)
+ *   class "raw_quantainium"         -> items_commodities_quantainium_raw (prefix vs suffix)
+ *   class "medicalSupplies_medPens" -> items_commodities_medpens
+ * The DB `name` matches the base value verbatim, so it drives the fallbacks.
+ *
+ * A RAW item never offers the bare/refined key: "Hephaestanite (R)" has no
+ * _raw key, and matching items_commodities_hephaestanite would stamp the raw
+ * item's label onto a different commodity. Callers resolve against the base's
+ * real key set, so a candidate that doesn't exist simply yields no override.
+ */
+export function commodityKeyCandidates(className: string, name: string): string[] {
+  const out = [`items_commodities_${className}`];
+  const isRaw = /^raw_/i.test(className) || RAW_SUFFIX.test(name);
+  const stem = name.replace(RAW_SUFFIX, "").trim();
+  if (isRaw) {
+    if (/^raw_/i.test(className)) out.push(`items_commodities_${className.slice(4)}_raw`);
+    out.push(`items_commodities_${keyToken(stem)}_raw`);
+  } else {
+    out.push(`items_commodities_${keyToken(stem)}`);
+  }
+  return out;
+}
+
+/**
+ * Resolve a commodity to its real global.ini key, trying each candidate in
+ * order as both the bare key and its `,P` parameter variant (some commodities
+ * only ship the ,P form — 4.9 has items_commodities_hephaestanite_raw,P but no
+ * bare equivalent). Candidate order is preserved, so a raw item still never
+ * reaches a refined key.
+ */
+function resolveCommodityKey(
+  className: string,
+  name: string,
+  validKeys?: Map<string, string>,
+): string | undefined {
+  for (const candidate of commodityKeyCandidates(className, name)) {
+    const direct = resolveKey(candidate, validKeys);
+    if (direct) return direct;
+    const asParam = validKeys?.get(`${candidate.toLowerCase()},p`);
+    if (asParam) return asParam;
+  }
+  return undefined;
+}
+
 /** Contraband warnings: prefix illegal commodity names with [!] */
 export function generateContrabandWarnings(
   rows: Array<{ className: string; name: string }>,
@@ -251,7 +342,7 @@ export function generateContrabandWarnings(
   const overrides: LabelOverride[] = [];
   for (const row of rows) {
     if (!row.className) continue;
-    const key = resolveKey(`items_commodities_${row.className}`, validKeys);
+    const key = resolveCommodityKey(row.className, row.name, validKeys);
     if (!key) continue;
     overrides.push({
       key,
@@ -298,11 +389,9 @@ export function generateMaterialShortNames(
     }
     if (!shortened) continue;
 
-    const candidates = [
-      `items_commodities_${row.className}`,
-      `item_Name${row.className}`,
-    ];
-    const key = candidates.map((c) => resolveKey(c, validKeys)).find(Boolean);
+    const key =
+      resolveCommodityKey(row.className, row.name, validKeys) ??
+      resolveKey(`item_Name${row.className}`, validKeys);
     if (!key) continue;
     overrides.push({
       key,
@@ -320,6 +409,13 @@ export function generateMaterialShortNames(
  * base string at override-generation time.
  */
 export const BP_APPEND_SENTINEL = "\0BP_APPEND\0";
+
+/**
+ * Sibling of BP_APPEND_SENTINEL: the /download endpoint emits the remainder
+ * BEFORE the untouched base value. Used for prefix-format short labels, where
+ * the tag leads and only the base knows the short text.
+ */
+export const BP_PREPEND_SENTINEL = "\0BP_PREPEND\0";
 
 /**
  * PascalCase vehicle_components.type → readable noun for a blueprint's
@@ -505,6 +601,87 @@ export function generateContractOverrides(
 // ---------------------------------------------------------------------------
 // Merge engine
 // ---------------------------------------------------------------------------
+
+/**
+ * Merge overrides into a base global.ini given as raw BYTES — the form the
+ * /download endpoint serves.
+ *
+ * Works byte-wise on purpose: the base is ~10MB and its values may hold
+ * non-ASCII text, so only keys (always ASCII, before the '=') are decoded and
+ * untouched lines are copied through verbatim. That keeps every byte we don't
+ * deliberately change bit-identical to CIG's file.
+ *
+ * An override value starting with BP_APPEND_SENTINEL / BP_PREPEND_SENTINEL
+ * keeps the base value and adds the remainder after / before it — the base is
+ * the only source of those strings (contract bodies, short-form item names).
+ * Any other value replaces the base value outright.
+ *
+ * `overrideMap` is keyed by LOWERCASE key; matching is case-insensitive and the
+ * file's original key casing is preserved on output.
+ */
+export function mergeGlobalIniBytes(
+  raw: Uint8Array,
+  overrideMap: Map<string, string>,
+): Uint8Array {
+  const chunks: Uint8Array[] = [];
+  const te = new TextEncoder();
+  let lineStart = 0;
+  for (let i = 0; i <= raw.length; i++) {
+    if (i === raw.length || raw[i] === 0x0A) {
+      const lineEnd = i;
+      let eqPos = -1;
+      for (let j = lineStart; j < lineEnd; j++) {
+        if (raw[j] === 0x3D) { eqPos = j; break; }
+      }
+      if (eqPos > lineStart) {
+        let keyEnd = eqPos;
+        while (keyEnd > lineStart && raw[keyEnd - 1] === 0x20) keyEnd--;
+        const keyBytes = raw.slice(lineStart, keyEnd);
+        // Skip the UTF-8 BOM on the first line.
+        const keyStr = String.fromCharCode(
+          ...(lineStart === 0 && keyBytes[0] === 0xEF ? keyBytes.slice(3) : keyBytes),
+        );
+        const override = overrideMap.get(keyStr.toLowerCase());
+        if (override !== undefined) {
+          chunks.push(raw.slice(lineStart, eqPos + 1));
+          if (override.startsWith(BP_APPEND_SENTINEL) || override.startsWith(BP_PREPEND_SENTINEL)) {
+            const prepend = override.startsWith(BP_PREPEND_SENTINEL);
+            const sentinel = prepend ? BP_PREPEND_SENTINEL : BP_APPEND_SENTINEL;
+            const addText = override.slice(sentinel.length);
+            let valEnd = lineEnd;
+            if (valEnd > 0 && raw[valEnd - 1] === 0x0D) valEnd--;
+            const origValBytes = raw.slice(eqPos + 1, valEnd);
+            if (prepend) {
+              chunks.push(te.encode(addText));
+              chunks.push(origValBytes);
+            } else {
+              chunks.push(origValBytes);
+              chunks.push(te.encode(addText));
+            }
+          } else {
+            chunks.push(te.encode(override));
+          }
+          if (lineEnd > 0 && raw[lineEnd - 1] === 0x0D) chunks.push(new Uint8Array([0x0D]));
+          if (i < raw.length) chunks.push(new Uint8Array([0x0A]));
+          lineStart = i + 1;
+          continue;
+        }
+      }
+      // Untouched line: emit original bytes verbatim.
+      chunks.push(raw.slice(lineStart, i < raw.length ? i + 1 : i));
+      lineStart = i + 1;
+    }
+  }
+
+  const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+  const output = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
 
 /**
  * Merge overrides into the base global.ini content.

--- a/src/routes/localization.ts
+++ b/src/routes/localization.ts
@@ -24,6 +24,7 @@ import {
   resolveCategoryFormat,
   searchGlobalIniKeys,
   applyCategoryPacks,
+  mergeGlobalIniBytes,
 } from "../lib/localization";
 
 /**
@@ -745,63 +746,7 @@ export function localizationRoutes() {
       overrideMap.set(o.key.toLowerCase(), o.value);
     }
 
-    // Merge: scan raw bytes line by line. For lines with a matching key,
-    // emit the replacement. For all others, emit the original bytes untouched.
-    const chunks: Uint8Array[] = [];
-    const te = new TextEncoder();
-    let lineStart = 0;
-    for (let i = 0; i <= raw.length; i++) {
-      if (i === raw.length || raw[i] === 0x0A) {
-        const lineEnd = i;
-        // Find '=' in this line
-        let eqPos = -1;
-        for (let j = lineStart; j < lineEnd; j++) {
-          if (raw[j] === 0x3D) { eqPos = j; break; }
-        }
-        if (eqPos > lineStart) {
-          let keyEnd = eqPos;
-          while (keyEnd > lineStart && raw[keyEnd - 1] === 0x20) keyEnd--;
-          const keyBytes = raw.slice(lineStart, keyEnd);
-          const keyStr = String.fromCharCode(...(lineStart === 0 && keyBytes[0] === 0xEF ? keyBytes.slice(3) : keyBytes));
-          const override = overrideMap.get(keyStr.toLowerCase());
-          if (override !== undefined) {
-            // Emit: original key bytes + '=' + override value + \r\n
-            chunks.push(raw.slice(lineStart, eqPos + 1));
-
-            if (override.startsWith("\0BP_APPEND\0")) {
-              // Append mode: emit original value + appended text
-              const appendText = override.slice("\0BP_APPEND\0".length);
-              // Extract original value bytes (after '=', before line end)
-              let valEnd = lineEnd;
-              if (valEnd > 0 && raw[valEnd - 1] === 0x0D) valEnd--;
-              const origValBytes = raw.slice(eqPos + 1, valEnd);
-              chunks.push(origValBytes);
-              chunks.push(te.encode(appendText));
-            } else {
-              chunks.push(te.encode(override));
-            }
-            if (lineEnd > 0 && raw[lineEnd - 1] === 0x0D) {
-              chunks.push(new Uint8Array([0x0D]));
-            }
-            if (i < raw.length) chunks.push(new Uint8Array([0x0A]));
-            lineStart = i + 1;
-            continue;
-          }
-        }
-        // Untouched line: emit original bytes
-        chunks.push(raw.slice(lineStart, i < raw.length ? i + 1 : i));
-        lineStart = i + 1;
-      }
-    }
-
-    // Concatenate chunks
-    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
-    const output = new Uint8Array(totalLen);
-    let offset = 0;
-    for (const chunk of chunks) {
-      output.set(chunk, offset);
-      offset += chunk.length;
-    }
+    const output = mergeGlobalIniBytes(raw, overrideMap);
 
     return new Response(output, {
       headers: {

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -3,8 +3,12 @@ import {
   humanizeComponentType,
   missileSeekerCode,
   generateItemLabels,
+  generateContrabandWarnings,
+  generateMaterialShortNames,
   ALL_LABEL_FIELDS,
   CATEGORY_AVAILABLE_FIELDS,
+  BP_APPEND_SENTINEL,
+  BP_PREPEND_SENTINEL,
   type ItemRow,
 } from "../src/lib/localization";
 
@@ -186,5 +190,212 @@ describe("label-field source of truth", () => {
 
   it("includes componentClass", () => {
     expect(ALL_LABEL_FIELDS).toContain("componentClass");
+  });
+});
+
+/**
+ * Commodity key resolution — a trade_commodities.class_name does not always
+ * match the game's own global.ini key. Real 4.9 cases:
+ *   class "quantanium"        -> key items_commodities_quantainium   (class misspelt)
+ *   class "raw_quantainium"   -> key items_commodities_quantainium_raw (prefix vs suffix)
+ *   class "medicalSupplies_medPens" -> key items_commodities_medpens
+ * The DB `name` is authoritative and matches the base value, so it drives the
+ * fallback candidates. A RAW item must never fall back to the refined key.
+ */
+describe("commodity key resolution", () => {
+  const keys = (...ks: string[]) => new Map(ks.map((k) => [k.toLowerCase(), k]));
+
+  it("resolves the exact class_name key", () => {
+    const out = generateContrabandWarnings(
+      [{ className: "titanium", name: "Titanium" }],
+      keys("items_commodities_titanium"),
+    );
+    expect(out).toEqual([
+      { key: "items_commodities_titanium", value: "[!] Titanium", original: "Titanium" },
+    ]);
+  });
+
+  it("falls back to the display-name key when class_name is misspelt (quantanium -> quantainium)", () => {
+    const out = generateContrabandWarnings(
+      [{ className: "quantanium", name: "Quantainium" }],
+      keys("items_commodities_quantainium"),
+    );
+    expect(out[0]?.key).toBe("items_commodities_quantainium");
+  });
+
+  it("maps a raw_* class to the game's <stem>_raw key", () => {
+    const out = generateContrabandWarnings(
+      [{ className: "raw_quantainium", name: "Quantainium (Raw)" }],
+      keys("items_commodities_quantainium_raw"),
+    );
+    expect(out[0]?.key).toBe("items_commodities_quantainium_raw");
+  });
+
+  it("NEVER falls back to the refined key for a raw item", () => {
+    // Hephaestanite (R) has no _raw key in the 4.9 base. Matching the refined
+    // key would stamp the raw item's label onto a different commodity.
+    const out = generateContrabandWarnings(
+      [{ className: "raw_hephaestanite", name: "Hephaestanite (R)" }],
+      keys("items_commodities_hephaestanite"),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("resolves via the ,P parameter variant when only that form exists", () => {
+    // 4.9: Hephaestanite (R)'s only raw key is items_commodities_hephaestanite_raw,P
+    // — the bare form doesn't exist. Same ,P handling the contract resolver uses.
+    const out = generateContrabandWarnings(
+      [{ className: "raw_hephaestanite", name: "Hephaestanite (R)" }],
+      keys("items_commodities_hephaestanite_raw,P"),
+    );
+    expect(out[0]?.key).toBe("items_commodities_hephaestanite_raw,P");
+  });
+
+  it("prefers the raw ,P key over a refined bare key", () => {
+    // Both present: the raw item must still never take the refined key.
+    const out = generateContrabandWarnings(
+      [{ className: "raw_hephaestanite", name: "Hephaestanite (R)" }],
+      keys("items_commodities_hephaestanite", "items_commodities_hephaestanite_raw,P"),
+    );
+    expect(out[0]?.key).toBe("items_commodities_hephaestanite_raw,P");
+  });
+
+  it("normalises an underscored/camelCase class via its display name", () => {
+    const out = generateContrabandWarnings(
+      [{ className: "medicalSupplies_medPens", name: "MedPens" }],
+      keys("items_commodities_medpens"),
+    );
+    expect(out[0]?.key).toBe("items_commodities_medpens");
+  });
+
+  it("emits nothing when no candidate exists in the base", () => {
+    const out = generateContrabandWarnings(
+      [{ className: "hpmc", name: "HexaPolyMesh Coating" }],
+      keys("items_commodities_unrelated"),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("shortens a raw material via its _raw key", () => {
+    const out = generateMaterialShortNames(
+      [{ className: "raw_quantainium", name: "Quantainium (Raw)" }],
+      keys("items_commodities_quantainium_raw"),
+    );
+    expect(out[0]).toEqual({
+      key: "items_commodities_quantainium_raw",
+      value: "Quant (Raw)",
+      original: "Quantainium (Raw)",
+    });
+  });
+
+  it("does not shorten a raw material onto the refined key", () => {
+    const out = generateMaterialShortNames(
+      [{ className: "raw_hephaestanite", name: "Hephaestanite (R)" }],
+      keys("items_commodities_hephaestanite"),
+    );
+    expect(out).toEqual([]);
+  });
+});
+
+
+/**
+ * Short-form labels — the game ships a second, shorter string for many items
+ * (item_Name<class>_short; 715 of them in the 4.9 base) used in compact UI.
+ * StarStrings sets both (item_NameGMISL_..._short=[CS1] Spark-G). Only the base
+ * knows the short text, so the tag is wrapped around it at merge time via a
+ * sentinel — the same trick the contract overrides use.
+ */
+describe("generateItemLabels — _short variants", () => {
+  const keys = (...ks: string[]) => new Map(ks.map((k) => [k.toLowerCase(), k]));
+
+  it("appends the tag to the game's short value (suffix format)", () => {
+    const rows: ItemRow[] = [itemRow({ className: "cooler_x", name: "FullStop", subType: "Cooler" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namecooler_x", "item_Namecooler_x_short"));
+    const short = out.find((o) => o.key === "item_Namecooler_x_short");
+    expect(short?.value).toBe(`${BP_APPEND_SENTINEL} [Cooler]`);
+  });
+
+  it("prepends the tag to the game's short value (prefix format)", () => {
+    const rows: ItemRow[] = [itemRow({ className: "gmisl_x", name: "Spark-G Missile", seeker: "CS" })];
+    const out = generateItemLabels(rows, { fields: ["seeker"], format: "prefix" },
+      keys("item_Namegmisl_x", "item_Namegmisl_x_short"));
+    const short = out.find((o) => o.key === "item_Namegmisl_x_short");
+    expect(short?.value).toBe(`${BP_PREPEND_SENTINEL}[CS] `);
+  });
+
+  it("still emits the long label alongside the short one", () => {
+    const rows: ItemRow[] = [itemRow({ className: "cooler_x", name: "FullStop", subType: "Cooler" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namecooler_x", "item_Namecooler_x_short"));
+    expect(out.find((o) => o.key === "item_Namecooler_x")?.value).toBe("FullStop [Cooler]");
+    expect(out).toHaveLength(2);
+  });
+
+  it("omits the short override when the base has no _short key", () => {
+    const rows: ItemRow[] = [itemRow({ className: "cooler_x", name: "FullStop", subType: "Cooler" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namecooler_x"));
+    expect(out.map((o) => o.key)).toEqual(["item_Namecooler_x"]);
+  });
+
+  it("omits the short override when there is no tag to add", () => {
+    const rows: ItemRow[] = [itemRow({ className: "cooler_x", name: "FullStop", subType: null, type: null })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namecooler_x", "item_Namecooler_x_short"));
+    expect(out.map((o) => o.key)).toEqual(["item_Namecooler_x"]);
+  });
+
+  it("emits no short override when no base key set is supplied", () => {
+    // Without validKeys we cannot know a _short key exists; emitting one would
+    // invent a phantom key.
+    const rows: ItemRow[] = [itemRow({ seeker: "EM" })];
+    const out = generateItemLabels(rows, { fields: ["seeker"], format: "prefix" });
+    expect(out).toHaveLength(1);
+  });
+});
+
+
+/**
+ * Item key conventions — CIG writes item labels under BOTH
+ *   item_Name<class>   (weapons, most components)
+ *   item_Name_<class>  (armour, helmets — note the underscore)
+ * Only building the first form left every fps_armour (1472) and fps_helmet
+ * (549) label unresolved in the 4.9 base, so those toggles did nothing.
+ */
+describe("generateItemLabels — item_Name_<class> underscore convention", () => {
+  const keys = (...ks: string[]) => new Map(ks.map((k) => [k.toLowerCase(), k]));
+
+  it("resolves the underscore variant when the bare form is absent (armour/helmets)", () => {
+    const rows: ItemRow[] = [
+      itemRow({ className: "ccc_heavy_armor_helmet_01_01_01", name: "Neoni Tengubi Helmet", subType: "Helmet" }),
+    ];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Name_ccc_heavy_armor_helmet_01_01_01"));
+    expect(out).toHaveLength(1);
+    expect(out[0].key).toBe("item_Name_ccc_heavy_armor_helmet_01_01_01");
+    expect(out[0].value).toBe("Neoni Tengubi Helmet [Helmet]");
+  });
+
+  it("prefers the bare item_Name<class> when both forms exist", () => {
+    const rows: ItemRow[] = [itemRow({ className: "cooler_x", name: "FullStop", subType: "Cooler" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namecooler_x", "item_Name_cooler_x"));
+    expect(out[0].key).toBe("item_Namecooler_x");
+  });
+
+  it("derives the _short key from whichever convention resolved", () => {
+    const rows: ItemRow[] = [itemRow({ className: "armor_x", name: "Pembroke", subType: "Backpack" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Name_armor_x", "item_Name_armor_x_short"));
+    expect(out.map((o) => o.key)).toEqual(["item_Name_armor_x", "item_Name_armor_x_short"]);
+    expect(out[1].value).toBe(`${BP_APPEND_SENTINEL} [Backpack]`);
+  });
+
+  it("still emits nothing when neither convention exists", () => {
+    const rows: ItemRow[] = [itemRow({ className: "ghost_item", name: "Ghost", subType: "X" })];
+    const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
+      keys("item_Namesomething_else"));
+    expect(out).toEqual([]);
   });
 });

--- a/test/localization-merge.test.ts
+++ b/test/localization-merge.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeGlobalIniBytes,
+  BP_APPEND_SENTINEL,
+  BP_PREPEND_SENTINEL,
+} from "../src/lib/localization";
+
+/**
+ * Byte-level merge used by /api/localization/download. It must keep every line
+ * it does not deliberately change bit-identical to CIG's file (values may be
+ * non-ASCII and the file is ~10MB, so only keys are decoded).
+ */
+const enc = (s: string) => new TextEncoder().encode(s);
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+const merge = (src: string, over: Record<string, string>) =>
+  dec(mergeGlobalIniBytes(enc(src), new Map(Object.entries(over))));
+
+describe("mergeGlobalIniBytes", () => {
+  it("replaces a matched key's value and leaves other lines untouched", () => {
+    const out = merge("a_key=Original\nother_key=Keep Me\n", { a_key: "Replaced" });
+    expect(out).toBe("a_key=Replaced\nother_key=Keep Me\n");
+  });
+
+  it("matches keys case-insensitively but preserves the file's original casing", () => {
+    const out = merge("item_NameCooler=FullStop\n", { "item_namecooler": "Tagged" });
+    expect(out).toBe("item_NameCooler=Tagged\n");
+  });
+
+  it("APPEND keeps the base value and adds text after it", () => {
+    const out = merge("k=Spark-G\n", { k: `${BP_APPEND_SENTINEL} [CS1]` });
+    expect(out).toBe("k=Spark-G [CS1]\n");
+  });
+
+  it("PREPEND keeps the base value and adds text before it", () => {
+    const out = merge("k=Spark-G\n", { k: `${BP_PREPEND_SENTINEL}[CS1] ` });
+    expect(out).toBe("k=[CS1] Spark-G\n");
+  });
+
+  it("preserves CRLF line endings when wrapping", () => {
+    const out = merge("k=Spark-G\r\n", { k: `${BP_PREPEND_SENTINEL}[CS1] ` });
+    expect(out).toBe("k=[CS1] Spark-G\r\n");
+  });
+
+  it("leaves a non-matching line's bytes completely untouched", () => {
+    const src = "; a comment\nno_equals_here\nkept=Ünïcodé Vàlue\n";
+    expect(merge(src, { absent: "x" })).toBe(src);
+  });
+
+  it("does not corrupt a non-ASCII base value when wrapping it", () => {
+    const out = merge("k=Ünïcodé\n", { k: `${BP_APPEND_SENTINEL} [S1]` });
+    expect(out).toBe("k=Ünïcodé [S1]\n");
+  });
+
+  it("handles a final line with no trailing newline", () => {
+    expect(merge("k=Val", { k: "New" })).toBe("k=New");
+  });
+
+  it("skips the UTF-8 BOM when matching the first key", () => {
+    const out = merge("﻿first_key=Val\n", { first_key: "New" });
+    expect(out).toContain("first_key=New");
+  });
+});


### PR DESCRIPTION
## Problem

The Localization Builder only ever built **one** key form per entity, so a large share of overrides silently no-opped against the 4.9 base. Found while validating the 4.9 load against the live `global.ini`.

## What was broken

| Issue | Impact (measured vs the live 4.9 base) |
|---|---|
| **Items use two conventions.** CIG writes labels under both `item_Name<class>` (weapons, most components) **and** `item_Name_<class>` (armour, helmets). We only built the bare form. | **fps_armour 0 → 1472**, **fps_helmets 0 → 549**. Those toggles were exposed in the UI but did nothing. Resolvable labels **1150 → 3233**. |
| **`_short` labels never emitted.** The game ships `item_Name<class>_short` for compact UI (715 keys in 4.9). | **+464** labels, incl. **326/330 FPS weapons**. |
| **Commodity `class_name` != key.** e.g. `quantanium` vs `items_commodities_quantainium`; `raw_quantainium` vs `quantainium_raw`; some exist only as `,P` variants. | Coverage **107 → 126** of 135. |

## Correctness evidence

- Underscore mapping verified: **1452/1472** armour and **543/549** helmet base values match our DB name *exactly*.
- Commodity fallbacks introduce **0** value-mismatches.
- **A raw item never falls back to the refined key.** `Hephaestanite (R)` has no bare `_raw` key; matching `items_commodities_hephaestanite` would stamp the raw item's label onto a *different* commodity. It now correctly resolves to `items_commodities_hephaestanite_raw,P`.
- The `_short` key is derived from whichever convention resolved, so the two cannot diverge.

## Merge refactor

The `/download` byte-merge lived inline in the route with **zero tests**, despite producing every user's file. Adding the new `BP_PREPEND` sentinel to untested byte logic wasn't acceptable, so it is extracted to `mergeGlobalIniBytes` — single implementation, now covered for replace / append / prepend / CRLF / BOM / non-ASCII / no-trailing-newline. Untouched lines still pass through byte-identical.

## Testing

- `npm run typecheck` clean
- `npx vitest run` — **877 passed / 1 skipped** (+17 new tests)
- Every fix TDD'd: RED confirmed before each change.

## Notes

- No migrations. Code-only.
- Materially changes what a user's merged INI contains (~2000 newly-labelled items), hence staging first.
