### PR TITLE
fix(blueprints): resolve clothing + carryable product names

### DIFF
--- a/src/routes/blueprints.ts
+++ b/src/routes/blueprints.ts
@@ -25,8 +25,12 @@ export function blueprintRoutes() {
   //   - fps_weapons     ("Novia Crossbow", "FS-9 LMG", ...)
   //   - fps_armour      ("Pembroke RG-46 Helmet", "Hardline AR2", ...)
   //   - fps_helmets     (helmet-specific item table)
+  //   - fps_clothing    ("Bellator Jacket", "Spettro Shoes", ...)
+  //   - fps_carryables  ("TH-01 Propulsor", "Probe", ...)
   //   - fps_ammo_types  (magazine names: "Novia Bolt Magazine")
   //   - vehicle_components (ship-mounted weapons + components)
+  // Miss a table here and its blueprints silently fall back to the
+  // machine-derived crafting_blueprints.name ("Hdtc Jacket 01 01 01").
   // Each gets a LIVE + PTU pair. First non-null wins via COALESCE.
   //
   // Builds (mig 0226) are nested under each blueprint as `builds[]`
@@ -53,6 +57,8 @@ export function blueprintRoutes() {
       ? `LEFT JOIN ptu_fps_weapons  pfw ON LOWER(pfw.class_name) = ${outItem}
          LEFT JOIN ptu_fps_armour   pfa ON LOWER(pfa.class_name) = ${outItem}
          LEFT JOIN ptu_fps_helmets  pfh ON LOWER(pfh.class_name) = ${outItem}
+         LEFT JOIN ptu_fps_clothing pfc ON LOWER(pfc.class_name) = ${outItem}
+         LEFT JOIN ptu_fps_carryables pfy ON LOWER(pfy.class_name) = ${outItem}
          LEFT JOIN ptu_fps_ammo_types pam ON LOWER(pam.class_name) = ${outItem}
          LEFT JOIN ptu_vehicle_components pvc ON LOWER(pvc.class_name) = ${outItem}`
       : ``;
@@ -75,6 +81,8 @@ export function blueprintRoutes() {
                   lfw.name, ${p("pfw.name")},
                   lfa.name, ${p("pfa.name")},
                   lfh.name, ${p("pfh.name")},
+                  lfc.name, ${p("pfc.name")},
+                  lfy.name, ${p("pfy.name")},
                   lam.name, ${p("pam.name")},
                   lvc.name, ${p("pvc.name")}
                 ) AS item_name
@@ -84,6 +92,8 @@ export function blueprintRoutes() {
          LEFT JOIN fps_weapons      lfw ON LOWER(lfw.class_name) = ${outItem}
          LEFT JOIN fps_armour       lfa ON LOWER(lfa.class_name) = ${outItem}
          LEFT JOIN fps_helmets      lfh ON LOWER(lfh.class_name) = ${outItem}
+         LEFT JOIN fps_clothing     lfc ON LOWER(lfc.class_name) = ${outItem}
+         LEFT JOIN fps_carryables   lfy ON LOWER(lfy.class_name) = ${outItem}
          LEFT JOIN fps_ammo_types   lam ON LOWER(lam.class_name) = ${outItem}
          LEFT JOIN vehicle_components     lvc ON LOWER(lvc.class_name) = ${outItem}
          ${ptuItemJoins}

--- a/test/blueprints-item-name.test.ts
+++ b/test/blueprints-item-name.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { setupTestDatabase } from "./apply-migrations";
+import { createTestUser, authHeaders } from "./helpers";
+
+/**
+ * Friendly product-name resolution for the blueprint list.
+ *
+ * crafting_blueprints.name is machine-derived from the class name for ~99% of
+ * rows ("Hdtc Jacket 01 01 01"), so the list resolves a real name by joining
+ * output_item to the item tables. Clothing and carryables were missing from
+ * that join, so real 4.9 blueprints (Bellator Jacket, TH-01 Propulsor, ...)
+ * fell back to the machine name.
+ */
+describe("GET /api/blueprints — item_name resolution", () => {
+  let sessionToken: string;
+
+  beforeAll(async () => {
+    await setupTestDatabase(env.DB);
+    const user = await createTestUser(env.DB);
+    sessionToken = user.sessionToken;
+
+    let gv = await env.DB.prepare("SELECT id FROM game_versions LIMIT 1").first<{ id: number }>();
+    if (!gv) {
+      await env.DB.prepare(
+        "INSERT INTO game_versions (uuid, code, channel, is_default) VALUES ('t-gv','test-live','LIVE',1)",
+      ).run();
+      gv = await env.DB.prepare("SELECT id FROM game_versions LIMIT 1").first<{ id: number }>();
+    }
+    const gvId = gv!.id;
+
+    const seedBp = async (uuid: string, outputItem: string) => {
+      await env.DB.prepare(
+        `INSERT INTO crafting_blueprints (uuid, tag, name, type, sub_type, craft_time_seconds, output_item)
+         VALUES (?, ?, ?, 'x', 'y', 60, ?)`,
+      ).bind(uuid, `BP_${uuid}`, "Machine Derived Name", outputItem).run();
+      await env.DB.prepare(
+        `INSERT INTO user_blueprints (user_id, blueprint_uuid, crafting_blueprint_id, is_owned)
+         SELECT ?, ?, id, 1 FROM crafting_blueprints WHERE uuid = ?`,
+      ).bind(user.userId, uuid, uuid).run();
+    };
+    const seedItem = async (table: string, cls: string, name: string) => {
+      await env.DB.prepare(
+        `INSERT INTO ${table} (uuid, class_name, name, game_version_id) VALUES (?, ?, ?, ?)`,
+      ).bind(`u-${cls}`, cls, name, gvId).run();
+    };
+
+    await seedBp("bp-clothing", "hdtc_jacket_01_01_01");
+    await seedBp("bp-carryable", "carryable_2h_fl_missionitem_prototype_ship_component_2_a");
+    await seedBp("bp-weapon", "behr_rifle_ballistic_03");
+
+    await seedItem("fps_clothing", "hdtc_jacket_01_01_01", "Bellator Jacket");
+    await seedItem("fps_carryables", "carryable_2h_fl_missionitem_prototype_ship_component_2_a", "TH-01 Propulsor");
+    await seedItem("fps_weapons", "behr_rifle_ballistic_03", "CQ7 Rifle");
+  });
+
+  const names = async (): Promise<Record<string, string | null>> => {
+    const res = await SELF.fetch("http://localhost/api/blueprints", {
+      headers: await authHeaders(sessionToken),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<Record<string, unknown>> };
+    return Object.fromEntries(
+      body.items.map((i) => [i.blueprint_uuid as string, (i.item_name as string) ?? null]),
+    );
+  };
+
+  it("resolves a clothing blueprint to its real item name", async () => {
+    expect((await names())["bp-clothing"]).toBe("Bellator Jacket");
+  });
+
+  it("resolves a carryable blueprint to its real item name", async () => {
+    expect((await names())["bp-carryable"]).toBe("TH-01 Propulsor");
+  });
+
+  it("still resolves weapons — existing join must not regress", async () => {
+    expect((await names())["bp-weapon"]).toBe("CQ7 Rifle");
+  });
+});


### PR DESCRIPTION
## Problem

`crafting_blueprints.name` is machine-derived from the class name for **99% of rows** (1584/1597 in 4.9) — e.g. `"Hdtc Jacket 01 01 01"`. That's by design: the list resolves a **real** product name by joining `output_item` to the item tables and exposing it as `item_name`.

But the join set was missing `fps_clothing` and `fps_carryables`, so those blueprints silently fell back to the machine name. A missing table degrades quietly, which is why it went unnoticed.

## Impact (measured against the 4.9 data in staging)

- **1583 / 1597 (99%)** blueprints already resolved a friendly name.
- **14 (1%)** fell back to the machine name. **8 of those are fixed here** — and all 8 are **new in 4.9**:

| Blueprint | Now resolves to |
|---|---|
| `BP_CRAFT_hdtc_jacket_01_01_01` | Bellator Jacket |
| `BP_CRAFT_hdtc_pants_01_01_01` | Bellator Trousers |
| `BP_CRAFT_hdtc_shirt_02_01_01` | Bellator Shirt and Waistcoat |
| `BP_CRAFT_hdtc_shoes_01_01_01` | Spettro Shoes |
| `BP_CRAFT_Carryable_2H_FL_MissionItem_prototype_ship_component_2_a` | TH-01 Propulsor |
| `BP_CRAFT_Carryable_2H_FL_MissionItem_microsatellite_a` | Probe |
| `BP_CRAFT_Carryable_2H_SQ_CollectorMaterial_002` | Metamaterial Test #152 |
| `BP_CRAFT_Carryable_2H_CY_CollectorMaterial_001` | Collectormaterial 001 |

## Not fixed here (upstream, not ours)

The remaining **6** ship an **empty `product_entity_class`** in the p4k record itself, so there is no `output_item` to join — nothing to resolve:

`Cool S04 Cnou Pioneer`, `Cds Undersuit 01 02 02`, `Cds Combat Heavy Helmet 01 02 02`, `Cds Combat Superheavy Backpack / Helmet / Suit 01 03 01`

5 of the 6 are new in 4.9 — likely CIG staging content for a future patch. The machine-name fallback is the correct graceful behaviour for these.

## Implementation

- Adds `fps_clothing` + `fps_carryables` to both the LIVE and PTU join sets, same `COALESCE` ordering. Both tables are already PTU-shadowed (`lib/ptu.ts` VERSIONED_TABLES, migration 0215), so the PTU path is safe; `crafting-ptu-resilience` still passes with PTU dropped.
- Comment updated to note that a missing table degrades silently.

## Testing

New E2E test (`test/blueprints-item-name.test.ts`) drives `GET /api/blueprints` against a seeded DB:
- clothing blueprint → real name
- carryable blueprint → real name
- weapon blueprint → real name (guards the existing join against regression)

RED confirmed first: clothing/carryable returned `null`, weapon passed.

- `npm run typecheck` clean
- `npx vitest run` — **851 passed / 1 skipped**

No migrations. Query-only.
