### PR TITLE
feat(localization): collapse placeholder churn in the What's-changed diff

### DIFF
--- a/frontend/src/pages/LocalizationBuilder/WhatsChangedBanner.jsx
+++ b/frontend/src/pages/LocalizationBuilder/WhatsChangedBanner.jsx
@@ -89,7 +89,17 @@ export default function WhatsChangedBanner() {
 
           {/* Tab body */}
           <div className="max-h-[40vh] overflow-y-auto">
-            {tab === 'changed' && <ChangedList items={diff.changed} />}
+            {tab === 'changed' && (
+              <>
+                <ChangedList items={diff.changed} />
+                {diff.placeholder_changed_count > 0 && (
+                  <div className="px-4 py-2 text-[11px] text-gray-600 border-t border-white/[0.04]">
+                    +{diff.placeholder_changed_count} placeholder housekeeping changes
+                    <span className="text-gray-700"> — unfinished CIG strings (&quot;PLACEHOLDER&quot;) that only gained an item tag</span>
+                  </div>
+                )}
+              </>
+            )}
             {tab === 'added' && <KeyList items={diff.added} tone="emerald" />}
             {tab === 'removed' && <KeyList items={diff.removed} tone="rose" />}
           </div>

--- a/frontend/src/pages/LocalizationBuilder/WhatsChangedBanner.test.jsx
+++ b/frontend/src/pages/LocalizationBuilder/WhatsChangedBanner.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import WhatsChangedBanner from './WhatsChangedBanner'
+
+// CIG ships literal "PLACEHOLDER" strings; 4.9 appended item tags to them.
+// The endpoint splits those out as placeholder_changed_count so the banner
+// lists only real content changes plus one collapsed housekeeping row.
+const DIFF = {
+  from: '4.8.2-live',
+  to: '4.9.0-live',
+  added_count: 2,
+  removed_count: 1,
+  changed_count: 1,
+  placeholder_changed_count: 10,
+  added: ['new_key_a', 'new_key_b'],
+  removed: ['old_key'],
+  changed: [{ key: 'Human_Surnames_3433', oldValue: 'Mussolini', newValue: 'Musson' }],
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => DIFF }))
+})
+
+describe('WhatsChangedBanner — placeholder housekeeping row', () => {
+  it('collapses placeholder churn into a single count row', async () => {
+    render(<WhatsChangedBanner />)
+    // auto-expands on first view of this patch; changed tab is the default
+    await waitFor(() => expect(screen.getByText(/placeholder housekeeping/i)).toBeInTheDocument())
+    expect(screen.getByText(/\+10 placeholder housekeeping changes/i)).toBeInTheDocument()
+    // the real change is still listed individually
+    expect(screen.getByText('Human_Surnames_3433')).toBeInTheDocument()
+  })
+
+  it('shows the REAL change count in the tab, not real+placeholder', async () => {
+    render(<WhatsChangedBanner />)
+    await waitFor(() => expect(screen.getByText(/Changed 1/)).toBeInTheDocument())
+  })
+
+  it('renders no housekeeping row when the patch has none', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ ...DIFF, placeholder_changed_count: 0 }) })
+    render(<WhatsChangedBanner />)
+    await waitFor(() => expect(screen.getByText('Human_Surnames_3433')).toBeInTheDocument())
+    expect(screen.queryByText(/placeholder housekeeping/i)).toBeNull()
+  })
+})

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -797,6 +797,34 @@ export function diffGlobalIni(oldContent: string, newContent: string): GlobalIni
   return { added, removed, changed };
 }
 
+/** True when a localization value is CIG's unfinished-string marker. */
+function isPlaceholderValue(v: string): boolean {
+  return v.trim().toUpperCase().startsWith("PLACEHOLDER");
+}
+
+/**
+ * Split value changes into real edits vs placeholder housekeeping.
+ *
+ * CIG ships literal "PLACEHOLDER" strings for unreleased items, and their 4.9
+ * loc pipeline appended the item class to every one ("PLACEHOLDER" →
+ * "PLACEHOLDER - cbd_hat_03_01_CFP_var2"). Both sides placeholder = pure
+ * housekeeping the diff banner collapses to a count. A placeholder becoming
+ * real text (or regressing to one) stays in `changed` — that IS content news.
+ */
+export function splitPlaceholderChanges(
+  changes: GlobalIniDiff["changed"],
+): { changed: GlobalIniDiff["changed"]; placeholderChanged: GlobalIniDiff["changed"] } {
+  const changed: GlobalIniDiff["changed"] = [];
+  const placeholderChanged: GlobalIniDiff["changed"] = [];
+  for (const c of changes) {
+    (isPlaceholderValue(c.oldValue) && isPlaceholderValue(c.newValue)
+      ? placeholderChanged
+      : changed
+    ).push(c);
+  }
+  return { changed, placeholderChanged };
+}
+
 // ---------------------------------------------------------------------------
 // Key browser search
 // ---------------------------------------------------------------------------

--- a/src/routes/localization.ts
+++ b/src/routes/localization.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_CONFIG,
   configFromRow,
   diffGlobalIni,
+  splitPlaceholderChanges,
   generateAsopOverrides,
   generateItemLabels,
   generateContrabandWarnings,
@@ -104,13 +105,19 @@ export function localizationRoutes() {
       }
 
       const diff = diffGlobalIni(fromIni, toIni);
+      // Placeholder→placeholder edits (CIG housekeeping on unfinished strings)
+      // are collapsed to a count so the banner shows real content changes.
+      const { changed, placeholderChanged } = splitPlaceholderChanges(diff.changed);
       return c.json({
         from: fromCode,
         to: toCode,
         added_count: diff.added.length,
         removed_count: diff.removed.length,
-        changed_count: diff.changed.length,
-        ...diff,
+        changed_count: changed.length,
+        placeholder_changed_count: placeholderChanged.length,
+        added: diff.added,
+        removed: diff.removed,
+        changed,
       });
     },
   );

--- a/test/localization-labels.test.ts
+++ b/test/localization-labels.test.ts
@@ -5,6 +5,7 @@ import {
   generateItemLabels,
   generateContrabandWarnings,
   generateMaterialShortNames,
+  splitPlaceholderChanges,
   ALL_LABEL_FIELDS,
   CATEGORY_AVAILABLE_FIELDS,
   BP_APPEND_SENTINEL,
@@ -397,5 +398,47 @@ describe("generateItemLabels — item_Name_<class> underscore convention", () =>
     const out = generateItemLabels(rows, { fields: ["subType"], format: "suffix" },
       keys("item_Namesomething_else"));
     expect(out).toEqual([]);
+  });
+});
+
+/**
+ * Placeholder housekeeping split — CIG ships literal "PLACEHOLDER" strings for
+ * unreleased items, and 4.9 appended the item class to every one of them
+ * ("PLACEHOLDER" -> "PLACEHOLDER - cbd_hat_03_01_CFP_var2"). Those are real
+ * value changes but pure housekeeping; the diff banner collapses them into a
+ * single count instead of listing each.
+ */
+describe("splitPlaceholderChanges", () => {
+  const ch = (key: string, oldValue: string, newValue: string) => ({ key, oldValue, newValue });
+
+  it("separates changes where BOTH sides are placeholder text", () => {
+    const { changed, placeholderChanged } = splitPlaceholderChanges([
+      ch("item_Desc_hat,P", "PLACEHOLDER", "PLACEHOLDER - cbd_hat_03_01"),
+      ch("Human_Surnames_3433", "Mussolini", "Musson"),
+    ]);
+    expect(changed.map(c => c.key)).toEqual(["Human_Surnames_3433"]);
+    expect(placeholderChanged.map(c => c.key)).toEqual(["item_Desc_hat,P"]);
+  });
+
+  it("keeps a change where a placeholder became REAL text (that's content news)", () => {
+    const { changed, placeholderChanged } = splitPlaceholderChanges([
+      ch("item_Desc_gun", "PLACEHOLDER", "A finely tuned ballistic rifle."),
+    ]);
+    expect(changed).toHaveLength(1);
+    expect(placeholderChanged).toHaveLength(0);
+  });
+
+  it("keeps a change where real text regressed TO a placeholder", () => {
+    const { changed } = splitPlaceholderChanges([
+      ch("item_Desc_x", "An actual description", "PLACEHOLDER - item_x"),
+    ]);
+    expect(changed).toHaveLength(1);
+  });
+
+  it("is case- and whitespace-tolerant", () => {
+    const { placeholderChanged } = splitPlaceholderChanges([
+      ch("k", "  placeholder", "Placeholder - thing"),
+    ]);
+    expect(placeholderChanged).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem

The "What's changed" banner on the Localization page faithfully lists every value change between patch bases — including CIG's placeholder housekeeping. In 4.9 CIG appended the item class to every unfinished string (`PLACEHOLDER` → `PLACEHOLDER - cbd_hat_03_01_CFP_var2`), and those cluster alphabetically (`item_Desc_*`), so the changed list reads placeholder-heavy (10 of 89 entries in 4.9 vs 4.8.2 — verified against the p4k `global.ini`: the change is CIG's, not the community base's).

## Fix

- `splitPlaceholderChanges` in `lib/localization.ts`: both-sides-placeholder edits split out of `changed`. A placeholder becoming **real text** — or regressing to one — stays listed: that IS content news.
- `/api/localization/diff` returns real `changed` + `placeholder_changed_count`; `changed_count` now counts real edits only.
- Banner renders one muted row: *"+N placeholder housekeeping changes — unfinished CIG strings that only gained an item tag."*

## Testing

- 4 new lib tests (split semantics incl. placeholder→real kept, case/whitespace tolerance)
- 3 new frontend tests (collapsed row renders, tab shows real count, row absent when none)
- typecheck clean · backend **884 passed** · frontend **421 passed**
