### PR TITLE
fix(loadout): drop the page's full-bleed black backdrop

### DIFF
--- a/frontend/src/pages/FpsLoadout/index.jsx
+++ b/frontend/src/pages/FpsLoadout/index.jsx
@@ -3,47 +3,41 @@ import LoadoutContainer from './LoadoutContainer'
 
 // Sci-fi HUD frame — clipped corners + soft glow border, matching the rest of
 // the FPS loadout visual system (see LoadoutContainer.jsx / mock v5).
+// The frame IS the page card: it sits directly in the app shell's p-4 gutter on
+// the shell's own background — no full-bleed backdrop of its own.
 export default function FpsLoadout() {
   return (
     <div
-      className="relative w-full overflow-hidden"
+      className="relative w-full overflow-hidden flex flex-col"
       style={{
-        height: 'calc(100vh - 3rem)',
+        height: 'calc(100vh - 2rem)',
         color: '#c0f6fe',
         fontFamily: 'sans-serif',
-        background: 'radial-gradient(1200px 700px at 50% -10%, #0c1822, #070b0f 60%)',
+        border: '1px solid rgba(120,200,220,0.30)',
+        borderRadius: 6,
+        background: 'linear-gradient(180deg, rgba(10,20,28,0.7), rgba(7,11,15,0.7))',
+        clipPath: 'polygon(0 14px, 14px 0, calc(100% - 14px) 0, 100% 14px, 100% calc(100% - 14px), calc(100% - 14px) 100%, 14px 100%, 0 calc(100% - 14px))',
       }}
     >
       {/* F288: page-level heading for screen readers (the visual UI uses styled spans). */}
       <h1 className="sr-only">FPS Loadout</h1>
       <div
-        className="absolute overflow-hidden flex flex-col"
+        data-testid="wip-banner"
+        className="flex-none flex items-center justify-center gap-2 uppercase"
         style={{
-          inset: 14,
-          border: '1px solid rgba(120,200,220,0.30)',
-          borderRadius: 6,
-          background: 'linear-gradient(180deg, rgba(10,20,28,0.7), rgba(7,11,15,0.7))',
-          clipPath: 'polygon(0 14px, 14px 0, calc(100% - 14px) 0, 100% 14px, 100% calc(100% - 14px), calc(100% - 14px) 100%, 14px 100%, 0 calc(100% - 14px))',
+          padding: '5px 12px',
+          letterSpacing: '2.4px',
+          fontSize: 11,
+          color: '#fbbf24',
+          background: 'rgba(251,191,36,0.08)',
+          borderBottom: '1px solid rgba(251,191,36,0.35)',
         }}
       >
-        <div
-          data-testid="wip-banner"
-          className="flex-none flex items-center justify-center gap-2 uppercase"
-          style={{
-            padding: '5px 12px',
-            letterSpacing: '2.4px',
-            fontSize: 11,
-            color: '#fbbf24',
-            background: 'rgba(251,191,36,0.08)',
-            borderBottom: '1px solid rgba(251,191,36,0.35)',
-          }}
-        >
-          <span aria-hidden="true">⚠</span>
-          <span>Work in progress — this page is under active development; layouts and stats may change</span>
-        </div>
-        <div className="relative flex-1 overflow-hidden">
-          <LoadoutContainer />
-        </div>
+        <span aria-hidden="true">⚠</span>
+        <span>Work in progress — this page is under active development; layouts and stats may change</span>
+      </div>
+      <div className="relative flex-1 overflow-hidden">
+        <LoadoutContainer />
       </div>
     </div>
   )


### PR DESCRIPTION
The FPS Loadout page painted its own near-black radial backdrop (`#0c1822 → #070b0f`) filling `calc(100vh - 3rem)`, then inset the HUD frame another 14px inside it — a dark slab visibly floating on the app shell's navy `sc-dark` background (reported after the WIP go-live).

The clipped-corner HUD frame is now the page card itself: it fills the shell's `p-4` gutter (`calc(100vh - 2rem)`) directly on the shell background, keeping the border, corner clips, panel gradient, and WIP banner unchanged.

Verified: build green, frontend 518 + worker 902 tests pass.