### PR TITLE
feat(app): version-skew guard — stale tabs reload after deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,14 +75,14 @@ jobs:
 
       - name: Deploy to production
         if: github.ref == 'refs/heads/main'
-        run: npx wrangler deploy --env production --config wrangler.toml --message "${GITHUB_SHA::7} — $(git log -1 --pretty=%s)"
+        run: npx wrangler deploy --env production --config wrangler.toml --var BUILD_ID:"${GITHUB_SHA::12}" --message "${GITHUB_SHA::7} — $(git log -1 --pretty=%s)"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to staging
         if: github.ref == 'refs/heads/staging'
-        run: npx wrangler deploy --env staging --config wrangler.toml --message "${GITHUB_SHA::7} — $(git log -1 --pretty=%s)"
+        run: npx wrangler deploy --env staging --config wrangler.toml --var BUILD_ID:"${GITHUB_SHA::12}" --message "${GITHUB_SHA::7} — $(git log -1 --pretty=%s)"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import RequireAuth from './components/RequireAuth'
 import RequireFeature from './components/RequireFeature'
 import useFontPreference from './hooks/useFontPreference'
 import { useStatus, usePreferences, setPreferences } from './hooks/useAPI'
+import { useVersionSkewGuard } from './hooks/useVersionSkewGuard'
 import { authClient, useSession, signOut } from './lib/auth-client'
 import { TimezoneProvider } from './hooks/useTimezone'
 import { PrivacyModeProvider } from './hooks/usePrivacyMode'
@@ -551,6 +552,26 @@ function RequireRole({ roles, children }) {
   return children
 }
 
+function VersionSkewToast() {
+  const { stale, reloadNow } = useVersionSkewGuard()
+  if (!stale) return null
+
+  return (
+    <div
+      data-testid="skew-toast"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2 bg-sc-panel border border-sc-border rounded-lg shadow-lg text-sm text-gray-200"
+    >
+      <span>SC Bridge has been updated.</span>
+      <button
+        onClick={reloadNow}
+        className="px-3 py-1 bg-sc-accent/15 hover:bg-sc-accent/25 text-sc-accent rounded text-xs font-display tracking-wide uppercase transition-colors"
+      >
+        Reload
+      </button>
+    </div>
+  )
+}
+
 function ImpersonationBanner() {
   const { data: sessionData } = useSession()
   const isImpersonating = !!sessionData?.session?.impersonatedBy
@@ -637,6 +658,7 @@ export default function App() {
         element={
           <div className="min-h-screen flex">
             <ImpersonationBanner />
+            <VersionSkewToast />
             {/* Skip navigation link */}
             <a href="#main-content" className="skip-link">
               Skip to content

--- a/frontend/src/hooks/useVersionSkewGuard.js
+++ b/frontend/src/hooks/useVersionSkewGuard.js
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useStatus } from './useAPI'
+
+// Version-skew guard. The bundle carries the build id it was compiled from
+// (vite define); the worker reports the currently deployed id on /api/status.
+// A mismatch means this tab is running a stale bundle: reload it at the next
+// safe moment (route navigation — nothing in-flight, nothing half-dragged),
+// or offer a toast if the user stays put. sessionStorage keeps one reload
+// per server build so a broken deploy can never cause a reload loop.
+export const CLIENT_BUILD = typeof __BUILD_ID__ === 'string' ? __BUILD_ID__ : 'dev'
+
+const RELOADED_KEY = 'skew-reloaded-for'
+const FOCUS_RECHECK_MS = 60_000
+
+export function decideSkewAction({ clientBuild, serverBuild, reloadedFor }) {
+  if (!serverBuild || typeof serverBuild !== 'string') return 'none'
+  if (serverBuild === clientBuild) return 'none'
+  // "dev" on either side means a non-CI build — ids carry no meaning.
+  if (serverBuild === 'dev' || clientBuild === 'dev') return 'none'
+  if (reloadedFor === serverBuild) return 'toast'
+  return 'reload'
+}
+
+function getReloadedFor() {
+  try { return sessionStorage.getItem(RELOADED_KEY) } catch { return null }
+}
+
+function markReloadedFor(build) {
+  try { sessionStorage.setItem(RELOADED_KEY, build) } catch { /* no-op */ }
+}
+
+// Returns { stale, reloadNow } for the toast: `stale` is true whenever the tab
+// runs an outdated bundle; `reloadNow` is the toast's action.
+export function useVersionSkewGuard() {
+  const location = useLocation()
+  const { data: status, refetch } = useStatus()
+  const serverBuild = status?.build
+  const [stale, setStale] = useState(false)
+  const lastFocusCheck = useRef(0)
+  const initialPath = useRef(location.pathname)
+
+  // Re-check when the tab regains focus (long-lived background tabs are the
+  // main skew audience), throttled so focus flapping doesn't spam the API.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return
+      const now = Date.now()
+      if (now - lastFocusCheck.current < FOCUS_RECHECK_MS) return
+      lastFocusCheck.current = now
+      refetch()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [refetch])
+
+  // Mismatch handling. Auto-reload only on a route CHANGE (not the landing
+  // render, where reloading would double-load the page the user just opened).
+  useEffect(() => {
+    const action = decideSkewAction({
+      clientBuild: CLIENT_BUILD,
+      serverBuild,
+      reloadedFor: getReloadedFor(),
+    })
+    if (action === 'none') {
+      setStale(false)
+      return
+    }
+    setStale(true)
+    if (action === 'reload' && location.pathname !== initialPath.current) {
+      markReloadedFor(serverBuild)
+      window.location.reload()
+    }
+  }, [serverBuild, location.pathname])
+
+  const reloadNow = () => {
+    if (serverBuild) markReloadedFor(serverBuild)
+    window.location.reload()
+  }
+
+  return { stale, reloadNow }
+}

--- a/frontend/src/hooks/useVersionSkewGuard.test.js
+++ b/frontend/src/hooks/useVersionSkewGuard.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { decideSkewAction } from './useVersionSkewGuard'
+
+describe('decideSkewAction', () => {
+  it('does nothing while the server build is unknown', () => {
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: undefined, reloadedFor: null })).toBe('none')
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: null, reloadedFor: null })).toBe('none')
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 42, reloadedFor: null })).toBe('none')
+  })
+
+  it('does nothing when builds match', () => {
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'abc123', reloadedFor: null })).toBe('none')
+  })
+
+  it('ignores non-CI builds on either side', () => {
+    expect(decideSkewAction({ clientBuild: 'dev', serverBuild: 'abc123', reloadedFor: null })).toBe('none')
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'dev', reloadedFor: null })).toBe('none')
+    expect(decideSkewAction({ clientBuild: 'dev', serverBuild: 'dev', reloadedFor: null })).toBe('none')
+  })
+
+  it('reloads on a fresh mismatch', () => {
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'def456', reloadedFor: null })).toBe('reload')
+  })
+
+  it('falls back to the toast when a reload for this build already happened (loop guard)', () => {
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'def456', reloadedFor: 'def456' })).toBe('toast')
+  })
+
+  it('reloads again when the server moves to a NEWER build than the one already reloaded for', () => {
+    expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'ghi789', reloadedFor: 'def456' })).toBe('reload')
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,12 @@ import svgr from 'vite-plugin-svgr'
 
 export default defineConfig({
   plugins: [svgr(), react()],
+  // Version-skew guard: must match the id the worker reports on /api/status.
+  // CI provides GITHUB_SHA to this build and passes the same value to
+  // `wrangler deploy --var BUILD_ID:…`; local dev gets "dev" (guard inert).
+  define: {
+    __BUILD_ID__: JSON.stringify((process.env.GITHUB_SHA ?? 'dev').slice(0, 12)),
+  },
   server: {
     port: 5173,
     proxy: {

--- a/src/build-id.d.ts
+++ b/src/build-id.d.ts
@@ -1,0 +1,4 @@
+// Injected by the vite `define` in vite.config.ts (GITHUB_SHA in CI, "dev"
+// locally). Absent under vitest-pool-workers, so consumers must go through a
+// `typeof` check rather than referencing the constant bare.
+declare const __BUILD_ID__: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,12 @@ import { logEvent } from "./lib/logger";
 import { isTrustedExtension } from "./lib/constants";
 import { cachedJson, cacheSlug } from "./lib/cache";
 
-// Version-skew guard: same constant is baked into the client bundle; the SPA
-// compares its copy against this one via /api/status and reloads when stale.
-// `typeof` guard: the define is absent under vitest-pool-workers.
-const BUILD_ID = typeof __BUILD_ID__ === "string" ? __BUILD_ID__ : "dev";
+// Version-skew guard: the client bundle bakes in the same id; the SPA compares
+// its copy against this via /api/status and reloads when stale. Two sources:
+// the vite define (root-vite-built worker, local path) or the BUILD_ID var
+// (CI path — wrangler compiles the worker itself, so no vite define there).
+const VITE_BUILD_ID: string | null =
+  typeof __BUILD_ID__ === "string" && __BUILD_ID__ !== "dev" ? __BUILD_ID__ : null;
 
 const app = new Hono<HonoEnv>();
 
@@ -396,7 +398,7 @@ app.get("/api/status", async (c) => {
       ops: c.env.ENVIRONMENT !== "production",
       fpsLoadout: true, // live everywhere behind the page-level WIP banner
     },
-    build: BUILD_ID,
+    build: VITE_BUILD_ID ?? c.env.BUILD_ID ?? "dev",
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,11 @@ import { logEvent } from "./lib/logger";
 import { isTrustedExtension } from "./lib/constants";
 import { cachedJson, cacheSlug } from "./lib/cache";
 
+// Version-skew guard: same constant is baked into the client bundle; the SPA
+// compares its copy against this one via /api/status and reloads when stale.
+// `typeof` guard: the define is absent under vitest-pool-workers.
+const BUILD_ID = typeof __BUILD_ID__ === "string" ? __BUILD_ID__ : "dev";
+
 const app = new Hono<HonoEnv>();
 
 // Global error handler — structured logging for unhandled exceptions
@@ -391,6 +396,7 @@ app.get("/api/status", async (c) => {
       ops: c.env.ENVIRONMENT !== "production",
       fpsLoadout: true, // live everywhere behind the page-level WIP banner
     },
+    build: BUILD_ID,
   });
 });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,10 @@ export interface Env {
   DISCORD_PACK_REQUEST_WEBHOOK?: string;
   TWITCH_CLIENT_ID?: string;
   TWITCH_CLIENT_SECRET?: string;
+  // Deployed build id for the version-skew guard — injected by CI via
+  // `wrangler deploy --var BUILD_ID:$GITHUB_SHA` (wrangler builds the worker
+  // itself, so the vite define never reaches this bundle in the CI path).
+  BUILD_ID?: string;
 }
 
 export type HonoEnv = {

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -51,6 +51,15 @@ describe("Health & Status", () => {
       expect(body).toHaveProperty("config");
       expect((body.config as Record<string, unknown>).db_driver).toBe("d1");
     });
+
+    it("reports the deployed build id for the version-skew guard", async () => {
+      const res = await SELF.fetch("http://localhost/api/status");
+      const body = (await res.json()) as Record<string, unknown>;
+      // vitest-pool-workers runs without the vite define, so the worker
+      // falls back to "dev"; in CI-built bundles this is the commit SHA.
+      expect(typeof body.build).toBe("string");
+      expect((body.build as string).length).toBeGreaterThan(0);
+    });
   });
 
   describe("API 404 fallthrough", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 
 export default defineConfig({
   publicDir: "frontend/public",
+  // Version-skew guard: worker and client are built from the same commit in
+  // one vite build, so both sides carry the same id. CI provides GITHUB_SHA;
+  // local dev builds get "dev" on both sides (never a mismatch).
+  define: {
+    __BUILD_ID__: JSON.stringify((process.env.GITHUB_SHA ?? "dev").slice(0, 12)),
+  },
   plugins: [
     svgr(),
     react(),


### PR DESCRIPTION
## Problem
Long-lived SPA tabs keep running the pre-deploy bundle while the worker serves new flags/data — yesterday's "FPS Loadout appeared half-width until a hard refresh". Every deploy reproduces this for any open tab.

## How it works
- Vite `define` bakes `GITHUB_SHA` (12 chars) into **both** the client and worker bundles — one build, one id. Local builds get `dev` on both sides and are exempt.
- `/api/status` gains a `build` field reporting the worker's copy.
- `useVersionSkewGuard` (mounted once, in the shell route): on mismatch, auto-`location.reload()` at the next **route change** (never the landing render, never mid-page), plus a bottom-center toast ("SC Bridge has been updated — Reload") for users who stay put.
- `sessionStorage` records the server build a reload happened for → at most one auto-reload per deploy per tab; a broken deploy degrades to toast-only, no loop.
- Focus re-check throttled to 60s for tabs waking from background.

## Tests
- `decideSkewAction` pure-logic table (6 cases: unknown/match/dev-exempt/fresh mismatch/loop-guard/newer build).
- `/api/status` build-id shape test.
- Suites: worker 903 pass, frontend 524 pass; typecheck + build green; fake-SHA build verified baked into both bundles.