### PR TITLE
fix(app): version-skew guard reloads stale landing renders

### DIFF
--- a/frontend/src/hooks/useVersionSkewGuard.js
+++ b/frontend/src/hooks/useVersionSkewGuard.js
@@ -38,7 +38,6 @@ export function useVersionSkewGuard() {
   const serverBuild = status?.build
   const [stale, setStale] = useState(false)
   const lastFocusCheck = useRef(0)
-  const initialPath = useRef(location.pathname)
 
   // Re-check when the tab regains focus (long-lived background tabs are the
   // main skew audience), throttled so focus flapping doesn't spam the API.
@@ -54,8 +53,11 @@ export function useVersionSkewGuard() {
     return () => document.removeEventListener('visibilitychange', onVisible)
   }, [refetch])
 
-  // Mismatch handling. Auto-reload only on a route CHANGE (not the landing
-  // render, where reloading would double-load the page the user just opened).
+  // Mismatch handling. Auto-reload on any detected mismatch, including the
+  // landing render — a stale bundle is exactly as stale on first paint as
+  // it is after a route change. The sessionStorage guard (one reload per
+  // server build) prevents a reload loop; a broken deploy degrades to the
+  // toast instead of reloading forever.
   useEffect(() => {
     const action = decideSkewAction({
       clientBuild: CLIENT_BUILD,
@@ -67,7 +69,7 @@ export function useVersionSkewGuard() {
       return
     }
     setStale(true)
-    if (action === 'reload' && location.pathname !== initialPath.current) {
+    if (action === 'reload') {
       markReloadedFor(serverBuild)
       window.location.reload()
     }

--- a/frontend/src/hooks/useVersionSkewGuard.test.js
+++ b/frontend/src/hooks/useVersionSkewGuard.test.js
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
 import { decideSkewAction } from './useVersionSkewGuard'
 
 describe('decideSkewAction', () => {
@@ -28,5 +29,74 @@ describe('decideSkewAction', () => {
 
   it('reloads again when the server moves to a NEWER build than the one already reloaded for', () => {
     expect(decideSkewAction({ clientBuild: 'abc123', serverBuild: 'ghi789', reloadedFor: 'def456' })).toBe('reload')
+  })
+})
+
+// Hook-level tests. CLIENT_BUILD is derived at module-load time from the
+// vite-injected __BUILD_ID__ global, which tests never define ("dev"),
+// tripping the dev exemption in decideSkewAction. Stub the global and
+// re-import the module fresh so the hook behaves like a real CI build.
+let mockPathname = '/dashboard'
+let mockStatusData = { build: 'abc123' }
+const mockRefetch = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: mockPathname }),
+}))
+
+vi.mock('./useAPI', () => ({
+  useStatus: () => ({ data: mockStatusData, refetch: mockRefetch }),
+}))
+
+describe('useVersionSkewGuard', () => {
+  let useVersionSkewGuard
+  let reloadSpy
+
+  beforeAll(async () => {
+    vi.stubGlobal('__BUILD_ID__', 'abc123')
+    vi.resetModules()
+    ;({ useVersionSkewGuard } = await import('./useVersionSkewGuard'))
+  })
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    mockPathname = '/dashboard'
+    mockRefetch.mockClear()
+    reloadSpy = vi.fn()
+    // jsdom's Location.prototype.reload isn't configurable enough for
+    // vi.spyOn — replace the whole location object instead.
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadSpy },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('auto-reloads on a fresh mismatch, even on the landing render', () => {
+    mockStatusData = { build: 'def456' }
+
+    renderHook(() => useVersionSkewGuard())
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem('skew-reloaded-for')).toBe('def456')
+  })
+
+  it('falls back to the toast once a reload for this server build already happened', () => {
+    mockStatusData = { build: 'def456' }
+    sessionStorage.setItem('skew-reloaded-for', 'def456')
+
+    const { result } = renderHook(() => useVersionSkewGuard())
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(result.current.stale).toBe(true)
+  })
+
+  it('does nothing when the client and server builds match', () => {
+    mockStatusData = { build: 'abc123' }
+
+    const { result } = renderHook(() => useVersionSkewGuard())
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(result.current.stale).toBe(false)
   })
 })


### PR DESCRIPTION
The guard deliberately skipped auto-reload on the landing render (toast-only), so a long-lived tab landing directly on a page keeps the stale bundle — the recurring "small layout until hard refresh" report. A stale bundle is exactly as stale on first paint as after a route change: now one guarded reload fires on landing too. The sessionStorage one-reload-per-server-build guard is unchanged, so a broken deploy still degrades to the toast rather than looping.

Tests: 3 new hook-level tests (renderHook, stubbed __BUILD_ID__ — RED-verified against pre-fix code); frontend 561/561; worker suite + typecheck green.

Note for reviewers: the codebase stores no screen dimensions anywhere — an externally suggested "read screen size on load" fix was investigated and ruled out; the skew landing window is the verified root cause.