### PR TITLE
feat(mining): rock mass slider + resistance-adjusted crack verdict

### DIFF
--- a/frontend/src/pages/Mining/MassSlider.jsx
+++ b/frontend/src/pages/Mining/MassSlider.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react'
+
+export default function MassSlider({ value, min, max, step = 1, defaultValue, label, unit, onChange }) {
+  const [textValue, setTextValue] = useState(String(value))
+  const [editing, setEditing] = useState(false)
+  const pct = max > min ? ((value - min) / (max - min)) * 100 : 0
+
+  // Keep text in sync when value changes externally (e.g. slider drag)
+  useEffect(() => {
+    if (!editing) setTextValue(String(value))
+  }, [value, editing])
+
+  const commitText = () => {
+    setEditing(false)
+    const parsed = parseFloat(textValue)
+    if (!isNaN(parsed)) {
+      onChange(Math.max(min, Math.min(max, parsed)))
+    } else {
+      setTextValue(String(value))
+    }
+  }
+
+  return (
+    <div className="bg-white/[0.02] border border-white/[0.05] rounded-lg p-3">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-medium text-gray-300">{label}</span>
+        <div className="flex items-center gap-1.5">
+          {defaultValue != null && (
+            <button
+              type="button"
+              onClick={() => onChange(defaultValue)}
+              tabIndex={-1}
+              title={`Reset to ${defaultValue}`}
+              className="text-[10px] text-gray-600 hover:text-gray-400 cursor-pointer transition-colors"
+            >
+              reset
+            </button>
+          )}
+          <input
+            type="text"
+            inputMode="decimal"
+            value={editing ? textValue : String(value)}
+            onChange={e => { setTextValue(e.target.value); setEditing(true) }}
+            onFocus={e => { setEditing(true); e.target.select() }}
+            onBlur={commitText}
+            onKeyDown={e => { if (e.key === 'Enter') { e.target.blur() } }}
+            className="w-16 text-right text-xs font-mono text-sc-accent bg-transparent border border-transparent hover:border-white/[0.08] focus:border-sc-accent/40 focus:bg-white/[0.03] rounded px-1 py-0.5 outline-none transition-all"
+          />
+          {unit && <span className="text-[10px] text-gray-500 font-mono">{unit}</span>}
+        </div>
+      </div>
+      <div className="relative">
+        <div className="h-1.5 rounded-full overflow-hidden bg-white/[0.06]">
+          <div className="h-full bg-transparent" />
+        </div>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={e => onChange(parseFloat(e.target.value))}
+          tabIndex={-1}
+          className="absolute inset-0 w-full h-1.5 opacity-0 cursor-pointer"
+          style={{ top: '0' }}
+        />
+        <div
+          className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white border-2 border-sc-accent shadow-[0_0_6px_rgba(34,211,238,0.5)] pointer-events-none transition-all duration-100"
+          style={{ left: `calc(${pct}% - 6px)` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Mining/MassSlider.jsx
+++ b/frontend/src/pages/Mining/MassSlider.jsx
@@ -50,9 +50,7 @@ export default function MassSlider({ value, min, max, step = 1, defaultValue, la
         </div>
       </div>
       <div className="relative">
-        <div className="h-1.5 rounded-full overflow-hidden bg-white/[0.06]">
-          <div className="h-full bg-transparent" />
-        </div>
+        <div className="h-1.5 rounded-full bg-white/[0.06]" />
         <input
           type="range"
           min={min}

--- a/frontend/src/pages/Mining/MassSlider.test.jsx
+++ b/frontend/src/pages/Mining/MassSlider.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MassSlider from './MassSlider'
+
+const baseProps = {
+  min: 0,
+  max: 10000,
+  step: 50,
+  defaultValue: 1000,
+  label: 'Rock Mass',
+  unit: 'kg',
+}
+
+describe('MassSlider', () => {
+  it('fires onChange live when the slider moves', () => {
+    const onChange = vi.fn()
+    render(<MassSlider {...baseProps} value={1000} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '2500' } })
+    expect(onChange).toHaveBeenCalledWith(2500)
+  })
+
+  it('commits typed text on Enter', () => {
+    const onChange = vi.fn()
+    render(<MassSlider {...baseProps} value={1000} onChange={onChange} />)
+    const box = screen.getByRole('textbox')
+    box.focus()
+    fireEvent.change(box, { target: { value: '9000' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith(9000)
+  })
+
+  it('clamps a committed value above max down to max', () => {
+    const onChange = vi.fn()
+    render(<MassSlider {...baseProps} value={1000} onChange={onChange} />)
+    const box = screen.getByRole('textbox')
+    box.focus()
+    fireEvent.change(box, { target: { value: '999999' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith(10000)
+  })
+
+  it('reverts silently on invalid text without firing onChange', () => {
+    const onChange = vi.fn()
+    render(<MassSlider {...baseProps} value={1000} onChange={onChange} />)
+    const box = screen.getByRole('textbox')
+    box.focus()
+    fireEvent.change(box, { target: { value: 'abc' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(box).toHaveValue('1000')
+  })
+
+  it('shows the prop value in the box when not editing', () => {
+    render(<MassSlider {...baseProps} value={3200} onChange={() => {}} />)
+    expect(screen.getByRole('textbox')).toHaveValue('3200')
+  })
+
+  // Tabbing between adjacent controls must not wade through the invisible
+  // range input or the reset button — those stay mouse-operable but skip
+  // out of the tab order (the QualitySlider lesson).
+  it('keeps only the number entry in the tab order', () => {
+    const { container } = render(<MassSlider {...baseProps} value={1000} onChange={() => {}} />)
+    const numberInput = screen.getByRole('textbox')
+    expect(numberInput).not.toHaveAttribute('tabIndex', '-1')
+
+    const rangeInput = container.querySelector('input[type="range"]')
+    expect(rangeInput).toHaveAttribute('tabIndex', '-1')
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBeGreaterThan(0)
+    buttons.forEach((button) => expect(button).toHaveAttribute('tabIndex', '-1'))
+  })
+})

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -286,6 +286,12 @@ export function formatDuration(seconds) {
 // rock's resistance"; this asks "can my DPS out-fill the mass-scaled decay
 // drain fast enough to ever finish the pool" (computeCrackFeasibility).
 // Styled like the page's other result cards (ChargeBar/StabilityCard/PowerBar).
+//
+// `feasibility` may be null (mass=0, or the scope's global params haven't
+// loaded) — only the OUTPUT row is gated on that. The slider itself always
+// renders: it's the only control that can set mass back to something
+// feasibility-computable, so hiding it alongside the row would strand the
+// player at mass=0 with no way back short of a page reload.
 function MassCrackCard({ mass, massConfig, onMassChange, feasibility }) {
   return (
     <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4 space-y-3">
@@ -299,17 +305,19 @@ function MassCrackCard({ mass, massConfig, onMassChange, feasibility }) {
         unit={massConfig.unit}
         onChange={onMassChange}
       />
-      <div className="flex items-center justify-between text-xs font-mono">
-        <span className={`font-semibold ${feasibility.canCrack ? 'text-emerald-400' : 'text-red-400'}`}>
-          {feasibility.canCrack ? 'CAN CRACK' : 'CANNOT CRACK'}
-        </span>
-        {feasibility.canCrack && (
-          <span className="text-gray-400">~{formatDuration(feasibility.timeToCrack)} best case</span>
-        )}
-        <span className={feasibility.marginPct >= 0 ? 'text-emerald-400' : 'text-red-400'}>
-          {feasibility.marginPct > 0 ? '+' : ''}{feasibility.marginPct.toFixed(0)}% power margin
-        </span>
-      </div>
+      {feasibility && (
+        <div className="flex items-center justify-between text-xs font-mono">
+          <span className={`font-semibold ${feasibility.canCrack ? 'text-emerald-400' : 'text-red-400'}`}>
+            {feasibility.canCrack ? 'CAN CRACK' : 'CANNOT CRACK'}
+          </span>
+          {feasibility.canCrack && (
+            <span className="text-gray-400">~{formatDuration(feasibility.timeToCrack)} best case</span>
+          )}
+          <span className={feasibility.marginPct >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+            {feasibility.marginPct > 0 ? '+' : ''}{feasibility.marginPct.toFixed(0)}% power margin
+          </span>
+        </div>
+      )}
     </div>
   )
 }
@@ -792,15 +800,16 @@ export default function RockCalculator({ data }) {
         <div className="space-y-4">
           {hasResults ? (
             <>
-              {/* Rock Mass — mass-scaled fill/decay crack feasibility */}
-              {crackFeasibility && (
-                <MassCrackCard
-                  mass={mass}
-                  massConfig={massConfig}
-                  onMassChange={setMass}
-                  feasibility={crackFeasibility}
-                />
-              )}
+              {/* Rock Mass — mass-scaled fill/decay crack feasibility. Always
+                  rendered once a loadout+rock are picked, even when
+                  `crackFeasibility` is null (mass=0, or no scope params) —
+                  see MassCrackCard's null-feasibility handling above. */}
+              <MassCrackCard
+                mass={mass}
+                massConfig={massConfig}
+                onMassChange={setMass}
+                feasibility={crackFeasibility}
+              />
 
               {/* CAN/CANNOT BREAK banner — prominent like RockBreaker */}
               <div className={`relative overflow-hidden rounded-xl border-2 p-6 text-center ${

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -464,13 +464,18 @@ export default function RockCalculator({ data }) {
     for (let i = 0; i < ship.slots.length; i++) {
       const laser = laserIds[i]
       if (!laser) continue
-      totalDps += laser.beam_dps || 0
 
       const slotModules = []
       for (let j = 0; j < (laser.module_slots || 0); j++) {
         const mod = moduleIds[`${i}-${j}`]
         if (mod) slotModules.push(mod)
       }
+
+      // Module damage multipliers stack multiplicatively on the host laser
+      // (Rieger MK3 ×1.25, Surge ×1.5, Focus MK1 ×0.85, ArgoGEO ×0.15).
+      // `?? 1` so a legitimate 0 multiplier isn't silently neutralised.
+      const damageMult = slotModules.reduce((p, m) => p * (m.damage_multiplier ?? 1), 1)
+      totalDps += (laser.beam_dps || 0) * damageMult
 
       const mods = computeEffectiveModifiers(laser, slotModules, i === 0 ? gadget : null)
       for (const key of MOD_KEYS) allMods[key] += mods[key]

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -8,6 +8,8 @@ import {
 } from './miningUtils'
 import { computeQualityBand } from './computeEffectiveRockStats'
 import { resolveRockEntity, buildMedianBaseByCategory } from './resolveRockEntity'
+import { computeCrackFeasibility } from './computeCrackFeasibility'
+import MassSlider from './MassSlider'
 import { encodeLoadoutParams, decodeLoadoutParams } from './loadoutCodec'
 import {
   serializeLoadout, resolveLoadout, upsertLoadout, removeLoadout,
@@ -255,6 +257,63 @@ export function buildElements(compositionUuid, compositions, elements) {
   })
 }
 
+// Per-equipment-scope Rock Mass slider config. `mining_global_params.scope`
+// values are 'ship' | 'fps' | 'ground_vehicle' (see migration
+// 0251_mining_global_params.sql). Only 'ship' is wired into RockCalculator
+// today — see the `massScope` comment below — but the fps/ground_vehicle
+// rows are kept ready so threading the real equipment scope through later is
+// a config lookup, not a rewrite.
+const MASS_SCOPE_CONFIG = {
+  ship: { min: 0, max: 40000, default: 8000, step: 100, unit: 'kg' },
+  fps: { min: 0, max: 10, default: 1, step: 0.1, unit: 'kg' },
+  ground_vehicle: { min: 0, max: 2000, default: 400, step: 10, unit: 'kg' },
+}
+
+// Format a best-case crack time (seconds, continuous) as a short duration.
+// Sub-10s values keep one decimal — the difference between 0.4s and 4s
+// matters at that scale, whole-second precision doesn't.
+export function formatDuration(seconds) {
+  if (typeof seconds !== 'number' || !(seconds > 0)) return '--'
+  if (seconds < 10) return `${seconds.toFixed(1)}s`
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return s > 0 ? `${m}m ${s}s` : `${m}m`
+}
+
+// Mass-scaled fill/decay verdict — a separate axis from the resistance-based
+// CAN/CANNOT BREAK banner below. That banner asks "does my DPS beat this
+// rock's resistance"; this asks "can my DPS out-fill the mass-scaled decay
+// drain fast enough to ever finish the pool" (computeCrackFeasibility).
+// Styled like the page's other result cards (ChargeBar/StabilityCard/PowerBar).
+function MassCrackCard({ mass, massConfig, onMassChange, feasibility }) {
+  return (
+    <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4 space-y-3">
+      <MassSlider
+        value={mass}
+        min={massConfig.min}
+        max={massConfig.max}
+        step={massConfig.step}
+        defaultValue={massConfig.default}
+        label="Rock Mass"
+        unit={massConfig.unit}
+        onChange={onMassChange}
+      />
+      <div className="flex items-center justify-between text-xs font-mono">
+        <span className={`font-semibold ${feasibility.canCrack ? 'text-emerald-400' : 'text-red-400'}`}>
+          {feasibility.canCrack ? 'CAN CRACK' : 'CANNOT CRACK'}
+        </span>
+        {feasibility.canCrack && (
+          <span className="text-gray-400">~{formatDuration(feasibility.timeToCrack)} best case</span>
+        )}
+        <span className={feasibility.marginPct >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+          {feasibility.marginPct > 0 ? '+' : ''}{feasibility.marginPct.toFixed(0)}% power margin
+        </span>
+      </div>
+    </div>
+  )
+}
+
 export default function RockCalculator({ data }) {
   const [shipIndex, setShipIndex] = useState(0)
   const ship = SHIP_PRESETS[shipIndex]
@@ -375,6 +434,20 @@ export default function RockCalculator({ data }) {
     [data?.global_params],
   )
 
+  // Rock Mass slider (crack feasibility). RockCalculator doesn't yet thread a
+  // real per-equipment scope through to its math — `shipScopeParams` above
+  // resolves 'ship' unconditionally, even when the ROC or FPS Multi-Tool
+  // SHIP_PRESETS entry is active — so mass stays on 'ship' too for now.
+  // Swapping to the real scope later is changing this one constant.
+  const massScope = 'ship'
+  const massConfig = MASS_SCOPE_CONFIG[massScope]
+  const [mass, setMass] = useState(massConfig.default)
+
+  const massScopeParams = useMemo(
+    () => (data?.global_params ?? []).find((p) => p.scope === massScope) ?? null,
+    [data?.global_params, massScope],
+  )
+
   const result = useMemo(() => {
     let totalDps = 0
     let allMods = {}
@@ -397,6 +470,11 @@ export default function RockCalculator({ data }) {
 
     return { totalDps, mods: allMods }
   }, [ship, laserIds, moduleIds, gadget])
+
+  const crackFeasibility = useMemo(
+    () => computeCrackFeasibility({ mass, globalParams: massScopeParams, effectiveDPS: result.totalDps }),
+    [mass, massScopeParams, result.totalDps],
+  )
 
   // Per-stat quality band. For each target composition we sample the quality
   // roll (lean/avg/rich); across variants (generic deposit mode) we average
@@ -714,6 +792,16 @@ export default function RockCalculator({ data }) {
         <div className="space-y-4">
           {hasResults ? (
             <>
+              {/* Rock Mass — mass-scaled fill/decay crack feasibility */}
+              {crackFeasibility && (
+                <MassCrackCard
+                  mass={mass}
+                  massConfig={massConfig}
+                  onMassChange={setMass}
+                  feasibility={crackFeasibility}
+                />
+              )}
+
               {/* CAN/CANNOT BREAK banner — prominent like RockBreaker */}
               <div className={`relative overflow-hidden rounded-xl border-2 p-6 text-center ${
                 displayStats.canBreak

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { Check, X as XIcon, ChevronDown, Activity, Save, Trash2 } from 'lucide-react'
+import { ChevronDown, Activity, Save, Trash2 } from 'lucide-react'
 import {
   SHIP_PRESETS, MOD_KEYS, MOD_LABELS, MOD_POSITIVE_IS_GOOD,
   computeEffectiveModifiers, formatModPct,
   friendlyElementName, instabilityBand,
 } from './miningUtils'
 import { computeQualityBand } from './computeEffectiveRockStats'
+import { computeDamageFactor } from './computeRockResistance'
 import { resolveRockEntity, buildMedianBaseByCategory } from './resolveRockEntity'
 import { computeCrackFeasibility } from './computeCrackFeasibility'
 import MassSlider from './MassSlider'
@@ -263,10 +264,23 @@ export function buildElements(compositionUuid, compositions, elements) {
 // today — see the `massScope` comment below — but the fps/ground_vehicle
 // rows are kept ready so threading the real equipment scope through later is
 // a config lookup, not a rewrite.
+//
+// The mass a player reads off the scan HUD carries no unit, and the scan
+// number is what this slider takes, so it is labelled without one — calling
+// it kg would be inventing a unit the game never states.
 const MASS_SCOPE_CONFIG = {
-  ship: { min: 0, max: 40000, default: 8000, step: 100, unit: 'kg' },
-  fps: { min: 0, max: 10, default: 1, step: 0.1, unit: 'kg' },
-  ground_vehicle: { min: 0, max: 2000, default: 400, step: 10, unit: 'kg' },
+  ship: { min: 0, max: 40000, default: 8000, step: 100, unit: 'Mass (scan HUD)' },
+  fps: { min: 0, max: 10, default: 1, step: 0.1, unit: 'Mass (scan HUD)' },
+  ground_vehicle: { min: 0, max: 2000, default: 400, step: 10, unit: 'Mass (scan HUD)' },
+}
+
+// Fit a mass to a scope's config: keep it when the new scope can represent
+// it, otherwise fall back to that scope's default. The three scopes' ranges
+// barely overlap (ship tops out at 40000, fps at 10), so carrying a mass
+// across a scope swap unchanged would leave the slider pinned off-scale.
+export function clampMassToScope(mass, config) {
+  if (typeof mass !== 'number' || !Number.isFinite(mass)) return config.default
+  return mass >= config.min && mass <= config.max ? mass : config.default
 }
 
 // Format a best-case crack time (seconds, continuous) as a short duration.
@@ -281,10 +295,11 @@ export function formatDuration(seconds) {
   return s > 0 ? `${m}m ${s}s` : `${m}m`
 }
 
-// Mass-scaled fill/decay verdict — a separate axis from the resistance-based
-// CAN/CANNOT BREAK banner below. That banner asks "does my DPS beat this
-// rock's resistance"; this asks "can my DPS out-fill the mass-scaled decay
-// drain fast enough to ever finish the pool" (computeCrackFeasibility).
+// The page's crack verdict: can this loadout's resistance-adjusted DPS
+// out-fill the mass-scaled decay drain fast enough to ever finish the power
+// pool (computeCrackFeasibility)? Both axes are in play — the rock's
+// element-composed resistance eats a fraction of your DPS, and its mass sets
+// how big a pool that reduced DPS has to fill against a proportional drain.
 // Styled like the page's other result cards (ChargeBar/StabilityCard/PowerBar).
 //
 // `feasibility` may be null (mass=0, or the scope's global params haven't
@@ -313,7 +328,7 @@ function MassCrackCard({ mass, massConfig, onMassChange, feasibility }) {
           {feasibility.canCrack && (
             <span className="text-gray-400">~{formatDuration(feasibility.timeToCrack)} best case</span>
           )}
-          <span className={feasibility.marginPct >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+          <span className={feasibility.marginPct > 0 ? 'text-emerald-400' : 'text-red-400'}>
             {feasibility.marginPct > 0 ? '+' : ''}{feasibility.marginPct.toFixed(0)}% power margin
           </span>
         </div>
@@ -446,10 +461,19 @@ export default function RockCalculator({ data }) {
   // real per-equipment scope through to its math — `shipScopeParams` above
   // resolves 'ship' unconditionally, even when the ROC or FPS Multi-Tool
   // SHIP_PRESETS entry is active — so mass stays on 'ship' too for now.
-  // Swapping to the real scope later is changing this one constant.
+  // Swapping to the real scope means making `massScope` derived rather than
+  // constant; the slider range, global-params row and the mass reset below
+  // all follow from it, so nothing else here needs rewriting.
   const massScope = 'ship'
   const massConfig = MASS_SCOPE_CONFIG[massScope]
   const [mass, setMass] = useState(massConfig.default)
+
+  // A scope swap changes the mass range by three orders of magnitude, so the
+  // mass carried over from the previous scope has to be refitted — otherwise
+  // a ship's 8000 survives into the FPS scope, whose slider maxes out at 10.
+  useEffect(() => {
+    setMass((prev) => clampMassToScope(prev, MASS_SCOPE_CONFIG[massScope]))
+  }, [massScope])
 
   const massScopeParams = useMemo(
     () => (data?.global_params ?? []).find((p) => p.scope === massScope) ?? null,
@@ -484,11 +508,6 @@ export default function RockCalculator({ data }) {
     return { totalDps, mods: allMods }
   }, [ship, laserIds, moduleIds, gadget])
 
-  const crackFeasibility = useMemo(
-    () => computeCrackFeasibility({ mass, globalParams: massScopeParams, effectiveDPS: result.totalDps }),
-    [mass, massScopeParams, result.totalDps],
-  )
-
   // Per-stat quality band. For each target composition we sample the quality
   // roll (lean/avg/rich); across variants (generic deposit mode) we average
   // each quality point. `band[key] = { lean, avg, rich }`. The `avg` point is
@@ -497,6 +516,7 @@ export default function RockCalculator({ data }) {
   const BAND_KEYS = [
     'effective_resistance',
     'effective_resistance_after_laser',
+    'rock_resistance',
     'effective_instability_delta',
     'effective_window_midpoint_delta',
     'effective_window_thinness_delta',
@@ -559,10 +579,12 @@ export default function RockCalculator({ data }) {
     const windowEnd = Math.min(1, baseMidpoint + windowSize / 2)
 
     const canBreak = result.totalDps > effectiveResistanceAfterLaser
-    // Margin: how much your power over/under-shoots the rock's resistance.
-    const marginPct = effectiveResistanceAfterLaser > 0
-      ? Math.abs((result.totalDps - effectiveResistanceAfterLaser) / effectiveResistanceAfterLaser) * 100
-      : 0
+
+    // The rock's real (element-composed) resistance eats a fraction of the
+    // beam: effectiveDPS = totalDps × damageFactor. This is the number the
+    // crack verdict runs on — see the resistance-composition findings doc.
+    const rockResistance = get('rock_resistance') ?? 0
+    const damageFactor = computeDamageFactor(rockResistance, result.mods.mod_resistance || 0)
 
     const band = instabilityBand(instabilityDelta)
     const leanInstability = aggregatedStats.band?.effective_instability_delta?.lean
@@ -571,16 +593,28 @@ export default function RockCalculator({ data }) {
     return {
       effectiveResistance,
       effectiveResistanceAfterLaser,
+      rockResistance,
+      damageFactor,
       instabilityDelta,
       windowStart,
       windowEnd,
       canBreak,
-      marginPct,
       band,
       leanInstability,
       richInstability,
     }
   }, [aggregatedStats, result.mods, result.totalDps, shipScopeParams])
+
+  // Crack feasibility runs on resistance-adjusted DPS, from the same avg
+  // quality point the rest of the results panel displays.
+  const crackFeasibility = useMemo(
+    () => computeCrackFeasibility({
+      mass,
+      globalParams: massScopeParams,
+      effectiveDPS: result.totalDps * (displayStats?.damageFactor ?? 1),
+    }),
+    [mass, massScopeParams, result.totalDps, displayStats?.damageFactor],
+  )
 
   // Elements list for single-variant display. A composition can list the same
   // element as multiple parts (e.g. CommonShipMineables_Iron has two iron_ore
@@ -805,10 +839,10 @@ export default function RockCalculator({ data }) {
         <div className="space-y-4">
           {hasResults ? (
             <>
-              {/* Rock Mass — mass-scaled fill/decay crack feasibility. Always
-                  rendered once a loadout+rock are picked, even when
-                  `crackFeasibility` is null (mass=0, or no scope params) —
-                  see MassCrackCard's null-feasibility handling above. */}
+              {/* Rock Mass — the page's crack verdict. Always rendered once a
+                  loadout+rock are picked, even when `crackFeasibility` is null
+                  (mass=0, or no scope params) — see MassCrackCard's
+                  null-feasibility handling above. */}
               <MassCrackCard
                 mass={mass}
                 massConfig={massConfig}
@@ -816,55 +850,17 @@ export default function RockCalculator({ data }) {
                 feasibility={crackFeasibility}
               />
 
-              {/* CAN/CANNOT BREAK banner — prominent like RockBreaker */}
-              <div className={`relative overflow-hidden rounded-xl border-2 p-6 text-center ${
-                displayStats.canBreak
-                  ? 'bg-emerald-500/10 border-emerald-500/40'
-                  : 'bg-red-500/10 border-red-500/40'
-              }`}>
-                {/* HUD corners */}
-                <div className={`absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 rounded-tl-xl ${displayStats.canBreak ? 'border-emerald-400/60' : 'border-red-400/60'}`} />
-                <div className={`absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 rounded-tr-xl ${displayStats.canBreak ? 'border-emerald-400/60' : 'border-red-400/60'}`} />
-                <div className={`absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 rounded-bl-xl ${displayStats.canBreak ? 'border-emerald-400/60' : 'border-red-400/60'}`} />
-                <div className={`absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 rounded-br-xl ${displayStats.canBreak ? 'border-emerald-400/60' : 'border-red-400/60'}`} />
-
-                {displayStats.canBreak ? (
-                  <div>
-                    <Check className="w-10 h-10 mx-auto mb-2 text-emerald-400" />
-                    <p className="text-2xl font-bold tracking-wider text-emerald-400 font-display"
-                      style={{ textShadow: '0 0 20px rgba(52, 211, 153, 0.5)' }}>
-                      CAN BREAK
-                    </p>
-                    <p className="text-xs text-gray-300 mt-1.5">
-                      Your laser overpowers this rock by{' '}
-                      <span className="text-emerald-400 font-semibold">{displayStats.marginPct.toFixed(0)}%</span>
-                      {displayStats.marginPct < 15 && <span className="text-amber-400"> — tight</span>}
-                    </p>
-                  </div>
-                ) : (
-                  <div>
-                    <XIcon className="w-10 h-10 mx-auto mb-2 text-red-400" />
-                    <p className="text-2xl font-bold tracking-wider text-red-400 font-display"
-                      style={{ textShadow: '0 0 20px rgba(239, 68, 68, 0.5)' }}>
-                      CANNOT BREAK
-                    </p>
-                    <p className="text-xs text-gray-300 mt-1.5">
-                      Short by <span className="text-red-400 font-semibold">{displayStats.marginPct.toFixed(0)}%</span> — needs a stronger laser or modules
-                    </p>
-                  </div>
-                )}
-
-                {aggregatedStats && aggregatedStats.count > 1 && (
-                  <p className="text-[10px] text-gray-500 mt-2">
-                    Showing average across {aggregatedStats.count} variants — pick a dominant element for exact values
-                  </p>
-                )}
-                {aggregatedStats?.is_fallback && (
-                  <p className="text-[10px] text-amber-400/80 mt-1">
-                    ≈ Typical values — this deposit type has no per-rock data; using median of similar rocks
-                  </p>
-                )}
-              </div>
+              {/* Data-quality caveats for everything in this panel. */}
+              {aggregatedStats && aggregatedStats.count > 1 && (
+                <p className="text-[10px] text-gray-500 text-center">
+                  Showing average across {aggregatedStats.count} variants — pick a dominant element for exact values
+                </p>
+              )}
+              {aggregatedStats?.is_fallback && (
+                <p className="text-[10px] text-amber-400/80 text-center">
+                  ≈ Typical values — this deposit type has no per-rock data; using median of similar rocks
+                </p>
+              )}
 
               {/* Power vs Rock bar (your power vs power-to-fracture) */}
               <div>

--- a/frontend/src/pages/Mining/RockCalculator.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.jsx
@@ -167,54 +167,6 @@ function StabilityCard({ band, leanInstability, richInstability }) {
   )
 }
 
-// Power bar inspired by RockBreaker — shows deficit/surplus
-function PowerBar({ totalDps, effectiveResistance, canBreak }) {
-  const maxVal = Math.max(totalDps, effectiveResistance, 1)
-  const powerPct = (totalDps / maxVal) * 100
-  const resistPct = (effectiveResistance / maxVal) * 100
-  const diff = totalDps - effectiveResistance
-  const diffPct = effectiveResistance > 0 ? ((diff / effectiveResistance) * 100) : 0
-
-  return (
-    <div className="bg-white/[0.03] backdrop-blur-md border border-white/[0.06] rounded-lg p-4">
-      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Power vs Rock</div>
-      <div className="relative h-6 bg-white/[0.04] rounded-full overflow-hidden">
-        {/* Power bar */}
-        <div
-          className={`absolute top-0 bottom-0 left-0 rounded-full transition-all duration-500 ${
-            canBreak ? 'bg-emerald-500/60' : 'bg-red-500/60'
-          }`}
-          style={{ width: `${powerPct}%` }}
-        />
-        {/* Resistance marker */}
-        <div
-          className="absolute top-0 bottom-0 w-0.5 bg-white/40"
-          style={{ left: `${resistPct}%` }}
-        />
-      </div>
-      <div className="flex items-center justify-between mt-2 text-xs font-mono">
-        <span className="text-gray-400">
-          Your power <span className="text-sc-accent">{totalDps.toFixed(0)}</span>
-        </span>
-        <span className={canBreak ? 'text-emerald-400' : 'text-red-400'}>
-          {canBreak ? 'Surplus' : 'Deficit'} {diffPct.toFixed(0)}%
-        </span>
-        <span className="text-gray-400">
-          Needs <span className="text-amber-400">{effectiveResistance.toFixed(0)}</span>
-        </span>
-      </div>
-    </div>
-  )
-}
-
-/** "Lean X → Rich Y" sub-line for a quality band. Collapses to a single
- *  value when lean and rich coincide (e.g. a single fixed-% element). */
-function fmtBandSpread(band, fmt = (v) => v.toFixed(2)) {
-  if (!band || band.lean == null || band.rich == null) return null
-  if (Math.abs(band.lean - band.rich) < 1e-6) return null
-  return `Lean ${fmt(band.lean)} → Rich ${fmt(band.rich)}`
-}
-
 /** Plain-language difficulty tag for a composition element, from its signed
  *  resistance modifier + raw instability. Lets a player read "easy" / "brutal"
  *  instead of "R:-0.400 I:50.000". */
@@ -265,13 +217,14 @@ export function buildElements(compositionUuid, compositions, elements) {
 // rows are kept ready so threading the real equipment scope through later is
 // a config lookup, not a rewrite.
 //
-// The mass a player reads off the scan HUD carries no unit, and the scan
-// number is what this slider takes, so it is labelled without one — calling
-// it kg would be inventing a unit the game never states.
+// No `unit`: the mass a player reads off the scan HUD is a bare number, and
+// the scan number is what this slider takes. Calling it kg would invent a
+// unit the game never states, so the card's label carries the provenance
+// ("Rock Mass (scan HUD)") and nothing trails the value.
 const MASS_SCOPE_CONFIG = {
-  ship: { min: 0, max: 40000, default: 8000, step: 100, unit: 'Mass (scan HUD)' },
-  fps: { min: 0, max: 10, default: 1, step: 0.1, unit: 'Mass (scan HUD)' },
-  ground_vehicle: { min: 0, max: 2000, default: 400, step: 10, unit: 'Mass (scan HUD)' },
+  ship: { min: 0, max: 40000, default: 8000, step: 100 },
+  fps: { min: 0, max: 10, default: 1, step: 0.1 },
+  ground_vehicle: { min: 0, max: 2000, default: 400, step: 10 },
 }
 
 // Fit a mass to a scope's config: keep it when the new scope can represent
@@ -300,7 +253,7 @@ export function formatDuration(seconds) {
 // pool (computeCrackFeasibility)? Both axes are in play — the rock's
 // element-composed resistance eats a fraction of your DPS, and its mass sets
 // how big a pool that reduced DPS has to fill against a proportional drain.
-// Styled like the page's other result cards (ChargeBar/StabilityCard/PowerBar).
+// Styled like the page's other result cards (ChargeBar/StabilityCard).
 //
 // `feasibility` may be null (mass=0, or the scope's global params haven't
 // loaded) — only the OUTPUT row is gated on that. The slider itself always
@@ -316,8 +269,7 @@ function MassCrackCard({ mass, massConfig, onMassChange, feasibility }) {
         max={massConfig.max}
         step={massConfig.step}
         defaultValue={massConfig.default}
-        label="Rock Mass"
-        unit={massConfig.unit}
+        label="Rock Mass (scan HUD)"
         onChange={onMassChange}
       />
       {feasibility && (
@@ -514,8 +466,6 @@ export default function RockCalculator({ data }) {
   // the expected rock and drives the can-break / charge math; lean→rich shows
   // how difficulty (esp. instability) climbs with quality.
   const BAND_KEYS = [
-    'effective_resistance',
-    'effective_resistance_after_laser',
     'rock_resistance',
     'effective_instability_delta',
     'effective_window_midpoint_delta',
@@ -564,8 +514,6 @@ export default function RockCalculator({ data }) {
 
     const get = (key) => aggregatedStats.band?.[key]?.avg ?? null
 
-    const effectiveResistance = get('effective_resistance') ?? 0
-    const effectiveResistanceAfterLaser = get('effective_resistance_after_laser') ?? effectiveResistance
     const instabilityDelta = get('effective_instability_delta') ?? 0
     const windowMidpointDelta = get('effective_window_midpoint_delta') ?? 0
     const windowThinnessDelta = get('effective_window_thinness_delta') ?? 0
@@ -578,8 +526,6 @@ export default function RockCalculator({ data }) {
     const windowStart = Math.max(0, baseMidpoint - windowSize / 2)
     const windowEnd = Math.min(1, baseMidpoint + windowSize / 2)
 
-    const canBreak = result.totalDps > effectiveResistanceAfterLaser
-
     // The rock's real (element-composed) resistance eats a fraction of the
     // beam: effectiveDPS = totalDps × damageFactor. This is the number the
     // crack verdict runs on — see the resistance-composition findings doc.
@@ -591,19 +537,15 @@ export default function RockCalculator({ data }) {
     const richInstability = aggregatedStats.band?.effective_instability_delta?.rich
 
     return {
-      effectiveResistance,
-      effectiveResistanceAfterLaser,
-      rockResistance,
       damageFactor,
       instabilityDelta,
       windowStart,
       windowEnd,
-      canBreak,
       band,
       leanInstability,
       richInstability,
     }
-  }, [aggregatedStats, result.mods, result.totalDps, shipScopeParams])
+  }, [aggregatedStats, result.mods, shipScopeParams])
 
   // Crack feasibility runs on resistance-adjusted DPS, from the same avg
   // quality point the rest of the results panel displays.
@@ -861,20 +803,6 @@ export default function RockCalculator({ data }) {
                   ≈ Typical values — this deposit type has no per-rock data; using median of similar rocks
                 </p>
               )}
-
-              {/* Power vs Rock bar (your power vs power-to-fracture) */}
-              <div>
-                <PowerBar
-                  totalDps={result.totalDps}
-                  effectiveResistance={displayStats.effectiveResistanceAfterLaser}
-                  canBreak={displayStats.canBreak}
-                />
-                {fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser, (v) => v.toFixed(0)) && (
-                  <p className="text-[10px] text-gray-600 mt-1.5 ml-1 font-mono">
-                    power needed by quality — {fmtBandSpread(aggregatedStats?.band?.effective_resistance_after_laser, (v) => v.toFixed(0))}
-                  </p>
-                )}
-              </div>
 
               {/* Stability — the danger axis, as a named band */}
               <StabilityCard

--- a/frontend/src/pages/Mining/RockCalculator.test.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.test.jsx
@@ -80,10 +80,15 @@ describe('RockCalculator — rock mass crack feasibility', () => {
     expect(screen.queryByText('Rock Mass')).not.toBeInTheDocument()
   })
 
-  it('stays inert (no mass card) when the scope has no global params loaded', () => {
+  it('keeps the slider visible but hides the verdict row when the scope has no global params loaded', () => {
     renderCalculator(baseData({ global_params: [] }))
     selectLaserAndRock()
-    expect(screen.queryByText('Rock Mass')).not.toBeInTheDocument()
+    // computeCrackFeasibility({ globalParams: null }) returns null -- the OUTPUT
+    // row (verdict/time/margin) is inert, but the slider itself must stay
+    // rendered: it's the only control that could ever recover a null result.
+    expect(screen.getByText('Rock Mass')).toBeInTheDocument()
+    expect(screen.queryByText('CAN CRACK')).not.toBeInTheDocument()
+    expect(screen.queryByText('CANNOT CRACK')).not.toBeInTheDocument()
   })
 
   it('defaults to the ship scope mass (8000) and renders CAN CRACK per the golden math', () => {
@@ -112,5 +117,30 @@ describe('RockCalculator — rock mass crack feasibility', () => {
     expect(screen.queryByText(/best case/)).not.toBeInTheDocument()
     // netRate -2000, marginPct -50 -- signed, no leading '+' for a negative value
     expect(screen.getByText('-50% power margin')).toBeInTheDocument()
+  })
+
+  it('mass=0 is a recoverable dead zone, not a self-inflicted trap', () => {
+    renderCalculator(baseData())
+    selectLaserAndRock()
+
+    const box = massBox()
+    box.focus()
+    fireEvent.change(box, { target: { value: '0' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+
+    // computeCrackFeasibility guards on !(mass > 0) -> null -- verdict row hides...
+    expect(screen.queryByText('CAN CRACK')).not.toBeInTheDocument()
+    expect(screen.queryByText('CANNOT CRACK')).not.toBeInTheDocument()
+    // ...but the slider (the only way to set mass back to something positive)
+    // must still be on screen, not vanish along with the verdict.
+    expect(screen.getByText('Rock Mass')).toBeInTheDocument()
+    expect(massBox()).toHaveValue('0')
+
+    // Recovery: raising mass again brings the verdict row back.
+    const box2 = massBox()
+    box2.focus()
+    fireEvent.change(box2, { target: { value: '8000' } })
+    fireEvent.keyDown(box2, { key: 'Enter' })
+    expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/Mining/RockCalculator.test.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.test.jsx
@@ -119,14 +119,14 @@ function selectLaserAndRock() {
 }
 
 function massBox() {
-  const label = screen.getByText('Rock Mass')
+  const label = screen.getByText('Rock Mass (scan HUD)')
   return within(label.parentElement).getByRole('textbox')
 }
 
 describe('RockCalculator — rock mass crack feasibility', () => {
   it('does not render the mass card before a rock + laser are selected', () => {
     renderCalculator(baseData())
-    expect(screen.queryByText('Rock Mass')).not.toBeInTheDocument()
+    expect(screen.queryByText('Rock Mass (scan HUD)')).not.toBeInTheDocument()
   })
 
   it('keeps the slider visible but hides the verdict row when the scope has no global params loaded', () => {
@@ -135,7 +135,7 @@ describe('RockCalculator — rock mass crack feasibility', () => {
     // computeCrackFeasibility({ globalParams: null }) returns null -- the OUTPUT
     // row (verdict/time/margin) is inert, but the slider itself must stay
     // rendered: it's the only control that could ever recover a null result.
-    expect(screen.getByText('Rock Mass')).toBeInTheDocument()
+    expect(screen.getByText('Rock Mass (scan HUD)')).toBeInTheDocument()
     expect(screen.queryByText('CAN CRACK')).not.toBeInTheDocument()
     expect(screen.queryByText('CANNOT CRACK')).not.toBeInTheDocument()
   })
@@ -182,7 +182,7 @@ describe('RockCalculator — rock mass crack feasibility', () => {
     expect(screen.queryByText('CANNOT CRACK')).not.toBeInTheDocument()
     // ...but the slider (the only way to set mass back to something positive)
     // must still be on screen, not vanish along with the verdict.
-    expect(screen.getByText('Rock Mass')).toBeInTheDocument()
+    expect(screen.getByText('Rock Mass (scan HUD)')).toBeInTheDocument()
     expect(massBox()).toHaveValue('0')
 
     // Recovery: raising mass again brings the verdict row back.
@@ -285,8 +285,25 @@ describe('RockCalculator — resistance-adjusted crack verdict', () => {
     renderCalculator(cTypeData())
     selectLaserAndRock()
 
+    // One label, no unit suffix: the scan HUD prints a bare number, and the
+    // old 'kg' invented a unit the game never states.
     expect(screen.queryByText('kg')).not.toBeInTheDocument()
-    expect(screen.getByText('Mass (scan HUD)')).toBeInTheDocument()
+    expect(screen.getByText('Rock Mass (scan HUD)')).toBeInTheDocument()
+    expect(screen.queryByText('Mass (scan HUD)')).not.toBeInTheDocument()
+  })
+
+  it('has retired the Power vs Rock bar — the crack card is the only feasibility read', () => {
+    // PowerBar measured DPS against laser_damage_full_value, the same
+    // damage-map normaliser that retired the banner (findings §2), so it
+    // could read "Deficit" directly above a "CAN CRACK" verdict.
+    renderCalculator(cTypeData({ lasers: [LASER_KLEIN] }))
+    selectLaser(/Klein S1 \(S1\)/)
+    selectRock()
+
+    expect(screen.queryByText('Power vs Rock')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Surplus|Deficit/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Your power/)).not.toBeInTheDocument()
+    expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
   })
 
   it('does not colour a dead-even power margin green', () => {

--- a/frontend/src/pages/Mining/RockCalculator.test.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.test.jsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import RockCalculator from './RockCalculator'
+
+vi.mock('../../lib/auth-client', () => ({
+  useSession: () => ({ data: null }),
+}))
+
+vi.mock('../../hooks/useAPI', () => ({
+  usePreferences: () => ({ data: null }),
+  setPreferences: () => Promise.resolve({ ok: true }),
+}))
+
+// Ship-scope golden fixture — power_capacity_per_mass=10, decay_per_mass=0.2
+// mirrors the golden values in computeCrackFeasibility.test.js so the
+// expected canCrack/timeToCrack/marginPct numbers below are cross-checked
+// against that module's own test suite, not just this integration test.
+const LASER = { id: 1, size: 1, name: 'Test Laser', beam_dps: 2000, module_slots: 0 }
+const COMPOSITION = {
+  uuid: 'comp-1',
+  name: 'Asteroid_CType_Iron',
+  class_name: 'Asteroid_CType_Iron',
+  rock_type: 'asteroid_ship',
+  composition_json: '[]',
+  deposit_name: 'Test Deposit',
+}
+const ROCK_ENTITY = {
+  composition_uuid: 'comp-1',
+  rock_category: 'ship_asteroid',
+  laser_damage_full_value: 500,
+}
+const SHIP_GLOBAL_PARAMS = { scope: 'ship', power_capacity_per_mass: 10, decay_per_mass: 0.2, optimal_window_size: 0.1 }
+
+function baseData(overrides = {}) {
+  return {
+    lasers: [LASER],
+    modules: [],
+    gadgets: [],
+    compositions: [COMPOSITION],
+    elements: [],
+    rock_entities: [ROCK_ENTITY],
+    global_params: [SHIP_GLOBAL_PARAMS],
+    ...overrides,
+  }
+}
+
+function renderCalculator(data) {
+  return render(
+    <MemoryRouter>
+      <RockCalculator data={data} />
+    </MemoryRouter>,
+  )
+}
+
+// Select the Prospector's S1 laser slot, then the deposit — this is what
+// "hasResults" (loadout + rock picked) requires before any result panel,
+// including the mass card, renders. The laser dropdown's trigger button
+// reads "None" (not the `placeholder` prop) because CustomSelect resolves
+// `options.find(o => o.value === value)` against the '' value first — an
+// existing quirk, not something this task touches — so open it by its
+// "S1 Laser" field label instead of trigger text.
+function selectLaserAndRock() {
+  const laserField = screen.getByText('S1 Laser').parentElement
+  fireEvent.click(within(laserField).getByRole('button'))
+  fireEvent.click(screen.getByText(/Test Laser \(S1\)/))
+
+  fireEvent.click(screen.getByText('Select a rock you scanned...'))
+  fireEvent.click(screen.getByText('Test Deposit'))
+}
+
+function massBox() {
+  const label = screen.getByText('Rock Mass')
+  return within(label.parentElement).getByRole('textbox')
+}
+
+describe('RockCalculator — rock mass crack feasibility', () => {
+  it('does not render the mass card before a rock + laser are selected', () => {
+    renderCalculator(baseData())
+    expect(screen.queryByText('Rock Mass')).not.toBeInTheDocument()
+  })
+
+  it('stays inert (no mass card) when the scope has no global params loaded', () => {
+    renderCalculator(baseData({ global_params: [] }))
+    selectLaserAndRock()
+    expect(screen.queryByText('Rock Mass')).not.toBeInTheDocument()
+  })
+
+  it('defaults to the ship scope mass (8000) and renders CAN CRACK per the golden math', () => {
+    renderCalculator(baseData())
+    selectLaserAndRock()
+
+    expect(massBox()).toHaveValue('8000')
+    expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
+    // mass 8000, effectiveDPS 2000 -> capacity 80000, decay 1600, netRate 400,
+    // timeToCrack 200s ("3m 20s"), marginPct 25 (matches computeCrackFeasibility.test.js)
+    expect(screen.getByText('~3m 20s best case')).toBeInTheDocument()
+    expect(screen.getByText('+25% power margin')).toBeInTheDocument()
+  })
+
+  it('flips to CANNOT CRACK and hides best-case time once mass pushes decay past effective DPS', () => {
+    renderCalculator(baseData())
+    selectLaserAndRock()
+
+    const box = massBox()
+    box.focus()
+    fireEvent.change(box, { target: { value: '20000' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+
+    // mass 20000 -> decay 4000 > effectiveDPS 2000 -> canCrack=false
+    expect(screen.getByText('CANNOT CRACK')).toBeInTheDocument()
+    expect(screen.queryByText(/best case/)).not.toBeInTheDocument()
+    // netRate -2000, marginPct -50 -- signed, no leading '+' for a negative value
+    expect(screen.getByText('-50% power margin')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Mining/RockCalculator.test.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import RockCalculator from './RockCalculator'
+import RockCalculator, { clampMassToScope } from './RockCalculator'
 
 vi.mock('../../lib/auth-client', () => ({
   useSession: () => ({ data: null }),
@@ -38,6 +38,32 @@ const ROCK_ENTITY = {
 }
 const SHIP_GLOBAL_PARAMS = { scope: 'ship', power_capacity_per_mass: 10, decay_per_mass: 0.2, optimal_window_size: 0.1 }
 
+// Helix S1's real 4.9 resistanceModifier (-30%).
+const LASER_HELIX = { id: 4, size: 1, name: 'Helix S1', beam_dps: 2000, module_slots: 0, mod_resistance: -0.3 }
+
+// The generic C-Type asteroid (`asteroid_ctype`) worked example from
+// tools/docs/superpowers/specs/
+// 2026-07-30-mining-resistance-composition-findings.md §6 — rockResistance
+// 0.2408 renormalised, which is what makes an 8000-mass rock genuinely
+// marginal for a single S1 laser.
+const C_TYPE_PARTS = [
+  { element: 'aluminium', min_pct: 50, max_pct: 50, probability: 0.85 },
+  { element: 'hephaestanite', min_pct: 45, max_pct: 45, probability: 0.6 },
+  { element: 'taranite', min_pct: 35, max_pct: 35, probability: 0.3 },
+  { element: 'bexalite', min_pct: 35, max_pct: 35, probability: 0.3 },
+  { element: 'gold', min_pct: 35, max_pct: 35, probability: 0.07 },
+  { element: 'quantainium', min_pct: 35, max_pct: 35, probability: 0.05 },
+]
+const C_TYPE_ELEMENT_ROWS = [
+  { class_name: 'aluminium', resistance: -0.4, instability: 0 },
+  { class_name: 'hephaestanite', resistance: -0.3, instability: 0 },
+  { class_name: 'taranite', resistance: 0.5, instability: 0 },
+  { class_name: 'bexalite', resistance: 0.6, instability: 0 },
+  { class_name: 'gold', resistance: 0.5, instability: 0 },
+  { class_name: 'quantainium', resistance: 0.95, instability: 0 },
+]
+const C_TYPE_COMPOSITION = { ...COMPOSITION, composition_json: JSON.stringify(C_TYPE_PARTS) }
+
 function baseData(overrides = {}) {
   return {
     lasers: [LASER],
@@ -49,6 +75,10 @@ function baseData(overrides = {}) {
     global_params: [SHIP_GLOBAL_PARAMS],
     ...overrides,
   }
+}
+
+function cTypeData(overrides = {}) {
+  return baseData({ compositions: [C_TYPE_COMPOSITION], elements: C_TYPE_ELEMENT_ROWS, ...overrides })
 }
 
 function renderCalculator(data) {
@@ -188,6 +218,106 @@ describe('RockCalculator — module damage multipliers in total DPS', () => {
     // Bare 2000 DPS: netRate 400 → 200s, margin 25%.
     expect(screen.getByText('~3m 20s best case')).toBeInTheDocument()
     expect(screen.getByText('+25% power margin')).toBeInTheDocument()
+  })
+})
+
+// The crack verdict is fed resistance-adjusted DPS:
+//   effectiveDPS = totalDps × (1 - clamp(rockResistance × (1 + Σmod), 0, 0.95))
+// Goldens below are the findings doc §6 table for asteroid_ctype at 2000 base
+// DPS / 8000 mass / ship scope (capacity 80000, decay 1600).
+describe('RockCalculator — resistance-adjusted crack verdict', () => {
+  it('a bare 2000 DPS laser CANNOT crack an 8000-mass C-Type asteroid', () => {
+    renderCalculator(cTypeData())
+    selectLaserAndRock()
+
+    // damageFactor 0.7592 → 1518.3 effective DPS vs 1600 decay → net -81.7.
+    expect(screen.getByText('CANNOT CRACK')).toBeInTheDocument()
+    expect(screen.getByText('-5% power margin')).toBeInTheDocument()
+    expect(screen.queryByText(/best case/)).not.toBeInTheDocument()
+  })
+
+  it('Helix S1 (-30% resistance) turns the same rock into a slow crack', () => {
+    renderCalculator(cTypeData({ lasers: [LASER_HELIX] }))
+    selectLaser(/Helix S1 \(S1\)/)
+    selectRock()
+
+    // effectiveResistance 0.1686 → 1662.8 DPS → net 62.8 → 80000/62.8 = 1273.6s
+    expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
+    expect(screen.getByText('~21m 14s best case')).toBeInTheDocument()
+    expect(screen.getByText('+4% power margin')).toBeInTheDocument()
+  })
+
+  it('Klein S1 (-45% resistance) cracks it in half the time', () => {
+    renderCalculator(cTypeData({ lasers: [LASER_KLEIN] }))
+    selectLaser(/Klein S1 \(S1\)/)
+    selectRock()
+
+    // effectiveResistance 0.1325 → 1735.1 DPS → net 135.1 → 592.3s
+    expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
+    expect(screen.getByText('~9m 52s best case')).toBeInTheDocument()
+    expect(screen.getByText('+8% power margin')).toBeInTheDocument()
+  })
+
+  it('is the page\'s only crack verdict — the CAN/CANNOT BREAK banner is gone', () => {
+    // The old banner compared DPS against laser_damage_full_value × curve
+    // factor, a rock-surface damage-map normaliser with no fracture meaning
+    // (findings §2). Replaced outright rather than shown alongside.
+    renderCalculator(cTypeData())
+    selectLaserAndRock()
+
+    expect(screen.queryByText('CAN BREAK')).not.toBeInTheDocument()
+    expect(screen.queryByText('CANNOT BREAK')).not.toBeInTheDocument()
+    expect(screen.getByText('CANNOT CRACK')).toBeInTheDocument()
+  })
+
+  it('keeps the multi-variant caveat that used to sit in the banner', () => {
+    const variant = { ...C_TYPE_COMPOSITION, uuid: 'comp-2', class_name: 'Asteroid_CType_Tin', name: 'Asteroid_CType_Tin' }
+    renderCalculator(cTypeData({
+      compositions: [C_TYPE_COMPOSITION, variant],
+      rock_entities: [ROCK_ENTITY, { ...ROCK_ENTITY, composition_uuid: 'comp-2' }],
+    }))
+    selectLaserAndRock()
+
+    expect(screen.getByText(/Showing average across 2 variants/)).toBeInTheDocument()
+  })
+
+  it('labels mass with no unit noun — the scan HUD number is unitless', () => {
+    renderCalculator(cTypeData())
+    selectLaserAndRock()
+
+    expect(screen.queryByText('kg')).not.toBeInTheDocument()
+    expect(screen.getByText('Mass (scan HUD)')).toBeInTheDocument()
+  })
+
+  it('does not colour a dead-even power margin green', () => {
+    renderCalculator(baseData()) // no elements → rockResistance 0 → 2000 DPS
+    selectLaserAndRock()
+
+    const box = massBox()
+    box.focus()
+    fireEvent.change(box, { target: { value: '10000' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+
+    // decay 2000 == DPS 2000 → netRate 0 → the pool never fills.
+    expect(screen.getByText('CANNOT CRACK')).toBeInTheDocument()
+    expect(screen.getByText('0% power margin')).toHaveClass('text-red-400')
+  })
+})
+
+// Mass is scope-scaled (ship 0–40000, fps 0–10, ground_vehicle 0–2000), so a
+// scope swap must not strand a ship-sized mass in an fps-sized range.
+describe('clampMassToScope', () => {
+  it('keeps a mass the new scope can represent', () => {
+    expect(clampMassToScope(5, { min: 0, max: 10, default: 1 })).toBe(5)
+  })
+
+  it('falls back to the new scope default when the mass is out of range', () => {
+    expect(clampMassToScope(8000, { min: 0, max: 10, default: 1 })).toBe(1)
+    expect(clampMassToScope(-5, { min: 0, max: 10, default: 1 })).toBe(1)
+  })
+
+  it('falls back when the mass is not a number', () => {
+    expect(clampMassToScope(undefined, { min: 0, max: 40000, default: 8000 })).toBe(8000)
   })
 })
 

--- a/frontend/src/pages/Mining/RockCalculator.test.jsx
+++ b/frontend/src/pages/Mining/RockCalculator.test.jsx
@@ -17,6 +17,12 @@ vi.mock('../../hooks/useAPI', () => ({
 // expected canCrack/timeToCrack/marginPct numbers below are cross-checked
 // against that module's own test suite, not just this integration test.
 const LASER = { id: 1, size: 1, name: 'Test Laser', beam_dps: 2000, module_slots: 0 }
+// A laser with one module slot + the Rieger MK3's real 4.9 damage multiplier
+// (1.25) — the Rieger series exists specifically to raise laser power.
+const LASER_MODULAR = { id: 2, size: 1, name: 'Modular Laser', beam_dps: 2000, module_slots: 1 }
+const MODULE_RIEGER = { id: 10, name: 'Rieger MK3', type: 'passive', damage_multiplier: 1.25 }
+// Klein S1's real 4.9 resistanceModifier (-45%) — the sought-after upgrade.
+const LASER_KLEIN = { id: 3, size: 1, name: 'Klein S1', beam_dps: 2000, module_slots: 0, mod_resistance: -0.45 }
 const COMPOSITION = {
   uuid: 'comp-1',
   name: 'Asteroid_CType_Iron',
@@ -60,13 +66,26 @@ function renderCalculator(data) {
 // `options.find(o => o.value === value)` against the '' value first — an
 // existing quirk, not something this task touches — so open it by its
 // "S1 Laser" field label instead of trigger text.
-function selectLaserAndRock() {
+function selectLaser(optionText = /Test Laser \(S1\)/) {
   const laserField = screen.getByText('S1 Laser').parentElement
   fireEvent.click(within(laserField).getByRole('button'))
-  fireEvent.click(screen.getByText(/Test Laser \(S1\)/))
+  fireEvent.click(screen.getByText(optionText))
+}
 
+function selectRock() {
   fireEvent.click(screen.getByText('Select a rock you scanned...'))
   fireEvent.click(screen.getByText('Test Deposit'))
+}
+
+function selectModule(slotLabel, optionText) {
+  const field = screen.getByText(slotLabel).parentElement
+  fireEvent.click(within(field).getByRole('button'))
+  fireEvent.click(screen.getByText(optionText))
+}
+
+function selectLaserAndRock() {
+  selectLaser()
+  selectRock()
 }
 
 function massBox() {
@@ -142,5 +161,45 @@ describe('RockCalculator — rock mass crack feasibility', () => {
     fireEvent.change(box2, { target: { value: '8000' } })
     fireEvent.keyDown(box2, { key: 'Enter' })
     expect(screen.getByText('CAN CRACK')).toBeInTheDocument()
+  })
+})
+
+// Total DPS is Σ_lasers (beam_dps × Π_modules damage_multiplier) — see the
+// resistance-composition findings doc §7.2. Ignoring damage_multiplier
+// understated a Rieger MK3 loadout by 25% and overstated a Focus MK1 by 18%.
+describe('RockCalculator — module damage multipliers in total DPS', () => {
+  it('multiplies laser DPS by an installed module damage multiplier', () => {
+    renderCalculator(baseData({ lasers: [LASER_MODULAR], modules: [MODULE_RIEGER] }))
+    selectLaser(/Modular Laser \(S1\)/)
+    selectModule('Module 1', 'Rieger MK3')
+    selectRock()
+
+    // 2000 × 1.25 = 2500 effective DPS; mass 8000 → decay 1600, netRate 900,
+    // capacity 80000 → 88.9s, margin 900/1600 = 56.25%.
+    expect(screen.getByText('~1m 29s best case')).toBeInTheDocument()
+    expect(screen.getByText('+56% power margin')).toBeInTheDocument()
+  })
+
+  it('leaves DPS untouched when no module is installed', () => {
+    renderCalculator(baseData({ lasers: [LASER_MODULAR], modules: [MODULE_RIEGER] }))
+    selectLaser(/Modular Laser \(S1\)/)
+    selectRock()
+
+    // Bare 2000 DPS: netRate 400 → 200s, margin 25%.
+    expect(screen.getByText('~3m 20s best case')).toBeInTheDocument()
+    expect(screen.getByText('+25% power margin')).toBeInTheDocument()
+  })
+})
+
+// mod_resistance is a CIG FloatModifierMultiplicative: negative = the rock
+// fights back less = better laser (findings §7.1). The bonuses panel must
+// colour a negative resistance modifier green, not red.
+describe('RockCalculator — resistance modifier direction', () => {
+  it('colours a resistance-reducing laser (Klein -45%) as a bonus, not a penalty', () => {
+    renderCalculator(baseData({ lasers: [LASER_KLEIN] }))
+    selectLaser(/Klein S1 \(S1\)/)
+    selectRock()
+
+    expect(screen.getByText('-45%')).toHaveClass('text-emerald-400')
   })
 })

--- a/frontend/src/pages/Mining/computeCrackFeasibility.js
+++ b/frontend/src/pages/Mining/computeCrackFeasibility.js
@@ -1,0 +1,25 @@
+// Crack feasibility from the validated mass model (see tools
+// docs/superpowers/specs/2026-07-30-rock-mass-cracking-findings.md —
+// DataCore constants cross-validated against the scmdb community solver).
+// capacity = powerCapacityPerMass × mass: the energy pool a laser must fill.
+// decay    = decayPerMass × mass: how fast the pool drains while charging.
+// A laser can crack the rock iff its resistance-adjusted DPS beats the
+// drain; best-case time assumes full throttle the whole way.
+export function computeCrackFeasibility({ mass, globalParams, effectiveDPS }) {
+  const cap = globalParams?.power_capacity_per_mass
+  const dec = globalParams?.decay_per_mass
+  if (typeof mass !== 'number' || !(mass > 0) || cap == null || dec == null) return null
+  const capacity = cap * mass
+  const decay = dec * mass
+  const dps = typeof effectiveDPS === 'number' ? effectiveDPS : 0
+  const netRate = dps - decay
+  const canCrack = netRate > 0
+  return {
+    capacity,
+    decay,
+    netRate,
+    canCrack,
+    timeToCrack: canCrack ? capacity / netRate : null,
+    marginPct: decay > 0 ? (netRate / decay) * 100 : 0,
+  }
+}

--- a/frontend/src/pages/Mining/computeCrackFeasibility.test.js
+++ b/frontend/src/pages/Mining/computeCrackFeasibility.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { computeCrackFeasibility } from './computeCrackFeasibility'
+
+describe('computeCrackFeasibility', () => {
+  describe('ship row (10/0.2)', () => {
+    const globalParams = { power_capacity_per_mass: 10, decay_per_mass: 0.2 }
+
+    it('mass 8000, effectiveDPS 2000: crack feasible (canCrack=true)', () => {
+      const result = computeCrackFeasibility({
+        mass: 8000,
+        globalParams,
+        effectiveDPS: 2000,
+      })
+      expect(result).toEqual({
+        capacity: 80000,
+        decay: 1600,
+        netRate: 400,
+        canCrack: true,
+        timeToCrack: 200,
+        marginPct: 25,
+      })
+    })
+
+    it('mass 8000, effectiveDPS 1600: cannot crack (netRate=0)', () => {
+      const result = computeCrackFeasibility({
+        mass: 8000,
+        globalParams,
+        effectiveDPS: 1600,
+      })
+      expect(result).toEqual({
+        capacity: 80000,
+        decay: 1600,
+        netRate: 0,
+        canCrack: false,
+        timeToCrack: null,
+        marginPct: 0,
+      })
+    })
+  })
+
+  describe('fps row (5/0.2)', () => {
+    const globalParams = { power_capacity_per_mass: 5, decay_per_mass: 0.2 }
+
+    it('mass 1: capacity=5, decay=0.2', () => {
+      const result = computeCrackFeasibility({
+        mass: 1,
+        globalParams,
+        effectiveDPS: 1,
+      })
+      expect(result.capacity).toBe(5)
+      expect(result.decay).toBe(0.2)
+    })
+  })
+
+  describe('gv row (4/0.2)', () => {
+    const globalParams = { power_capacity_per_mass: 4, decay_per_mass: 0.2 }
+
+    it('mass 400: capacity=1600, decay=80', () => {
+      const result = computeCrackFeasibility({
+        mass: 400,
+        globalParams,
+        effectiveDPS: 1,
+      })
+      expect(result.capacity).toBe(1600)
+      expect(result.decay).toBe(80)
+    })
+  })
+
+  describe('guards', () => {
+    const globalParams = { power_capacity_per_mass: 10, decay_per_mass: 0.2 }
+
+    it('mass 0: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 0,
+        globalParams,
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('mass -5: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: -5,
+        globalParams,
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('missing power_capacity_per_mass: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 100,
+        globalParams: { decay_per_mass: 0.2 },
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('missing decay_per_mass: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 100,
+        globalParams: { power_capacity_per_mass: 10 },
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('undefined globalParams: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 100,
+        globalParams: undefined,
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('null globalParams: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 100,
+        globalParams: null,
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('non-number mass: returns null', () => {
+      const result = computeCrackFeasibility({
+        mass: 'invalid',
+        globalParams,
+        effectiveDPS: 1,
+      })
+      expect(result).toBeNull()
+    })
+
+    it('undefined effectiveDPS treated as 0', () => {
+      const result = computeCrackFeasibility({
+        mass: 100,
+        globalParams,
+        effectiveDPS: undefined,
+      })
+      expect(result.netRate).toBe(-20) // 0 - (0.2 * 100)
+    })
+  })
+})

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.js
@@ -1,3 +1,5 @@
+import { computeRockResistance } from './computeRockResistance'
+
 /**
  * Pure math for the Rock Calculator. Implements the game's actual fracture
  * model - see tools/docs/design/2026-06-01-rock-calculator-rewrite.md
@@ -64,6 +66,10 @@ export function computeEffectiveRockStats({
   return {
     effective_resistance: effectiveResistance,
     effective_resistance_after_laser: effectiveResistanceAfterLaser,
+    // The rock's real (element-composed) resistance, on the same quality roll
+    // as everything else here so the crack verdict and the results panel
+    // describe the same expected rock.
+    rock_resistance: computeRockResistance(elements, q),
     effective_instability_delta: instabilityDelta,
     effective_window_midpoint_delta: windowMidpointDelta,
     effective_window_thinness_delta: windowThinnessDelta,

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.js
@@ -55,8 +55,11 @@ export function computeEffectiveRockStats({
   const globalResist = globalParams?.resistance_curve_factor ?? 1.0
   const effectiveResistance = base * (1 + resistanceDelta) * globalResist
 
+  // CIG stores resistance modifiers as FloatModifierMultiplicative and the
+  // extractor keeps them as raw/100 without flipping the sign, so they apply
+  // as × (1 + mod): a NEGATIVE modifier (Klein -45%) softens the rock.
   const laserResistMod = laserMods?.mod_resistance ?? 0
-  const effectiveResistanceAfterLaser = effectiveResistance * (1 - laserResistMod)
+  const effectiveResistanceAfterLaser = effectiveResistance * (1 + laserResistMod)
 
   return {
     effective_resistance: effectiveResistance,

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
@@ -65,15 +65,34 @@ describe('computeEffectiveRockStats', () => {
     expect(result.effective_resistance).toBeCloseTo(1000, 0)
   })
 
-  it('applies laser mod_resistance after global scaling', () => {
+  // Resistance modifiers are CIG FloatModifierMultiplicative values stored by
+  // the extractor as raw/100 with no sign flip, so they apply as × (1 + mod):
+  // a POSITIVE mod_resistance makes the rock harder. See
+  // tools/docs/superpowers/specs/2026-07-30-mining-resistance-composition-findings.md
+  // §7.1 — the previous (1 - mod) reading ranked every mining laser backwards
+  // (Arbor +25 read as the best laser, Klein -45 as the worst).
+  it('applies laser mod_resistance after global scaling — positive mod hardens the rock', () => {
     const result = computeEffectiveRockStats({
       rockEntity: { laser_damage_full_value: 2500 },
       elements: [ce({ element: 'x', min_pct: 100, max_pct: 100, element_resistance: 0 })],
       globalParams: GLOBAL_SHIP,
       laserMods: { mod_resistance: 0.08 },
     })
-    // 2500 * 1.0 * 1.0 * (1 - 0.08) = 2300
-    expect(result.effective_resistance_after_laser).toBeCloseTo(2300, 0)
+    // 2500 * 1.0 * 1.0 * (1 + 0.08) = 2700
+    expect(result.effective_resistance_after_laser).toBeCloseTo(2700, 0)
+  })
+
+  it('a resistance-reducing laser (Klein -45%) softens the rock', () => {
+    const args = {
+      rockEntity: { laser_damage_full_value: 2500 },
+      elements: [ce({ element: 'x', min_pct: 100, max_pct: 100, element_resistance: 0 })],
+      globalParams: GLOBAL_SHIP,
+    }
+    const bare = computeEffectiveRockStats({ ...args, laserMods: { mod_resistance: 0 } })
+    const klein = computeEffectiveRockStats({ ...args, laserMods: { mod_resistance: -0.45 } })
+    expect(klein.effective_resistance_after_laser).toBeLessThan(bare.effective_resistance_after_laser)
+    // 2500 * (1 - 0.45) = 1375
+    expect(klein.effective_resistance_after_laser).toBeCloseTo(1375, 0)
   })
 
   it('negative element_resistance lowers the effective resistance', () => {

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
@@ -106,6 +106,41 @@ describe('computeEffectiveRockStats', () => {
     expect(result.effective_resistance).toBeCloseTo(1500, 0)
   })
 
+  // rock_resistance rides the same quality roll as the other stats so the
+  // crack verdict and the results panel read the same expected rock. The
+  // value itself is computeRockResistance's contract (own suite); this
+  // asserts it is exposed and quality-sampled here.
+  it('exposes the composed rock_resistance (C-Type golden 0.2408)', () => {
+    const result = computeEffectiveRockStats({
+      rockEntity: { laser_damage_full_value: 2500 },
+      elements: [
+        ce({ element: 'aluminium', min_pct: 50, max_pct: 50, probability: 0.85, element_resistance: -0.4 }),
+        ce({ element: 'hephaestanite', min_pct: 45, max_pct: 45, probability: 0.6, element_resistance: -0.3 }),
+        ce({ element: 'taranite', min_pct: 35, max_pct: 35, probability: 0.3, element_resistance: 0.5 }),
+        ce({ element: 'bexalite', min_pct: 35, max_pct: 35, probability: 0.3, element_resistance: 0.6 }),
+        ce({ element: 'gold', min_pct: 35, max_pct: 35, probability: 0.07, element_resistance: 0.5 }),
+        ce({ element: 'quantainium', min_pct: 35, max_pct: 35, probability: 0.05, element_resistance: 0.95 }),
+      ],
+      globalParams: GLOBAL_SHIP,
+      laserMods: { mod_resistance: 0 },
+    })
+    expect(result.rock_resistance).toBeCloseTo(0.2408, 4)
+  })
+
+  it('rock_resistance follows the quality roll', () => {
+    const rock = (qualityRoll) => computeEffectiveRockStats({
+      rockEntity: { laser_damage_full_value: 1000 },
+      elements: [
+        ce({ element: 'quantainium', min_pct: 10, max_pct: 40, probability: 1, element_resistance: 0.95 }),
+        ce({ element: 'iron', min_pct: 60, max_pct: 60, probability: 1, element_resistance: -0.4 }),
+      ],
+      globalParams: GLOBAL_SHIP,
+      laserMods: { mod_resistance: 0 },
+      qualityRoll,
+    })
+    expect(rock(1).rock_resistance).toBeGreaterThan(rock(0).rock_resistance)
+  })
+
   it('instability and window come from globals + element deltas (Q3)', () => {
     const result = computeEffectiveRockStats({
       rockEntity: { laser_damage_full_value: 1000 },

--- a/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
+++ b/frontend/src/pages/Mining/computeEffectiveRockStats.test.js
@@ -110,7 +110,7 @@ describe('computeEffectiveRockStats', () => {
   // crack verdict and the results panel read the same expected rock. The
   // value itself is computeRockResistance's contract (own suite); this
   // asserts it is exposed and quality-sampled here.
-  it('exposes the composed rock_resistance (C-Type golden 0.2408)', () => {
+  it('exposes the composed rock_resistance (C-Type golden 0.24085)', () => {
     const result = computeEffectiveRockStats({
       rockEntity: { laser_damage_full_value: 2500 },
       elements: [
@@ -124,7 +124,7 @@ describe('computeEffectiveRockStats', () => {
       globalParams: GLOBAL_SHIP,
       laserMods: { mod_resistance: 0 },
     })
-    expect(result.rock_resistance).toBeCloseTo(0.2408, 4)
+    expect(result.rock_resistance).toBeCloseTo(0.24085, 5)
   })
 
   it('rock_resistance follows the quality roll', () => {

--- a/frontend/src/pages/Mining/computeRockResistance.js
+++ b/frontend/src/pages/Mining/computeRockResistance.js
@@ -1,0 +1,69 @@
+// Rock resistance from element composition, and the 0–1 damage factor it
+// implies. See tools/docs/superpowers/specs/
+// 2026-07-30-mining-resistance-composition-findings.md.
+//
+// A rock carries no resistance field of its own — difficulty is composed
+// entirely from its element list's `elementResistance` values (-1…+1). The
+// blend is NOT a weighted average: it is a sequential screen (probabilistic
+// OR) over elements sorted hardest-first, so a trace of quantainium raises
+// resistance a lot while soft elements scale back down what has accumulated.
+
+// Composition fraction exponent for the resistance blend. Literal 0.6 matches
+// the scmdb reference solver. Ship scope's mining_global_params
+// .resistance_curve_factor is also 0.6, so the two are numerically identical
+// for the only scope RockCalculator uses; fps/ground_vehicle are 0.33, and
+// whether that column IS this exponent is unproven — verify before switching
+// to it if the real equipment scope is ever threaded through.
+const RESISTANCE_COMPOSITION_EXPONENT = 0.6
+
+// Effective resistance can never reach 1.0 (that would zero the damage factor
+// outright). 0.95 is also exactly the elementResistance of the hardest real
+// ores — quantainium, riccite, savrilium, lindinium.
+const MAX_EFFECTIVE_RESISTANCE = 0.95
+
+/**
+ * Rock resistance as a signed fraction in (-1, 1).
+ *
+ * `qualityRoll` (0..1) picks where in each element's [min_pct, max_pct] range
+ * the instance rolled, the same axis computeEffectiveRockStats samples.
+ */
+export function computeRockResistance(elements, qualityRoll = 0.5) {
+  const q = Math.min(1, Math.max(0, qualityRoll ?? 0.5))
+  const parts = []
+  for (const el of elements ?? []) {
+    const prob = el.probability ?? 1.0
+    if (!(prob > 0)) continue
+    const lo = el.min_pct ?? 0
+    const hi = el.max_pct ?? 0
+    parts.push({
+      w: ((lo + (hi - lo) * q) / 100) * prob,
+      r: el.stats?.element_resistance ?? 0,
+    })
+  }
+  const total = parts.reduce((s, p) => s + p.w, 0)
+  if (!(total > 0)) return 0
+
+  parts.sort((a, b) => b.r - a.r) // hardest element first
+  let d = 0
+  for (const p of parts) {
+    // Renormalise to a real composition (fractions summing to 1). Without
+    // this the raw percentages sum well past 100%, the blend saturates, and
+    // every variant of a rock type collapses to the same resistance.
+    const frac = p.w / total
+    const c = Math.max(-1, Math.min(1,
+      Math.pow(frac, RESISTANCE_COMPOSITION_EXPONENT) * p.r))
+    d += c > 0 ? c * (1 - d) : c * d
+  }
+  return d
+}
+
+/**
+ * 0–1 damage factor: multiply base DPS by this to get effective DPS.
+ *
+ * `modResistance` is the stacked laser/module/gadget resistance modifier as a
+ * fraction (-0.45 = Klein S1's -45%), applied multiplicatively as (1 + mod).
+ */
+export function computeDamageFactor(rockResistance, modResistance = 0) {
+  const effective = (rockResistance ?? 0) * (1 + (modResistance ?? 0))
+  return 1 - Math.max(0, Math.min(MAX_EFFECTIVE_RESISTANCE, effective))
+}

--- a/frontend/src/pages/Mining/computeRockResistance.test.js
+++ b/frontend/src/pages/Mining/computeRockResistance.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { computeRockResistance, computeDamageFactor } from './computeRockResistance'
+
+// Golden fixture: the generic C-Type asteroid (`asteroid_ctype`) worked
+// example in tools/docs/superpowers/specs/
+// 2026-07-30-mining-resistance-composition-findings.md §6. min_pct == max_pct
+// so the fixture pins the midpoint the doc's table uses regardless of
+// qualityRoll.
+const el = (element, midPct, probability, resistance) => ({
+  element,
+  min_pct: midPct,
+  max_pct: midPct,
+  probability,
+  stats: { element_resistance: resistance },
+})
+
+const C_TYPE = [
+  el('aluminium', 50, 0.85, -0.4),
+  el('hephaestanite', 45, 0.6, -0.3),
+  el('taranite', 35, 0.3, 0.5),
+  el('bexalite', 35, 0.3, 0.6),
+  el('gold', 35, 0.07, 0.5),
+  el('quantainium', 35, 0.05, 0.95),
+]
+
+describe('computeRockResistance', () => {
+  it('matches the C-Type asteroid golden (0.2408)', () => {
+    expect(computeRockResistance(C_TYPE)).toBeCloseTo(0.2408, 4)
+  })
+
+  it('renormalises percentages — scaling every weight leaves the result unchanged', () => {
+    // Raw (unnormalised) percentages sum to 235% for asteroid_ctype and the
+    // screen blend saturates, giving 0.4909 for every variant. Renormalising
+    // makes the blend a composition, so a uniform rescale is a no-op.
+    const scaled = C_TYPE.map((e) => ({ ...e, probability: e.probability * 3 }))
+    expect(computeRockResistance(scaled)).toBeCloseTo(computeRockResistance(C_TYPE), 10)
+  })
+
+  it('is independent of input order (it sorts by resistance DESC internally)', () => {
+    const shuffled = [C_TYPE[3], C_TYPE[0], C_TYPE[5], C_TYPE[2], C_TYPE[4], C_TYPE[1]]
+    expect(computeRockResistance(shuffled)).toBeCloseTo(computeRockResistance(C_TYPE), 10)
+  })
+
+  it('skips parts that cannot roll (probability 0)', () => {
+    const withGhost = [...C_TYPE, el('riccite', 40, 0, 0.95)]
+    expect(computeRockResistance(withGhost)).toBeCloseTo(computeRockResistance(C_TYPE), 10)
+  })
+
+  it('a trace of a hard element contributes sub-linearly, not proportionally', () => {
+    // 2% quantainium: pow(0.02, 0.6) * 0.95 = 0.0909, not 0.019.
+    const trace = [el('quantainium', 2, 1, 0.95), el('iron', 98, 1, 0)]
+    expect(computeRockResistance(trace)).toBeCloseTo(0.0909, 4)
+  })
+
+  it('an all-soft rock bottoms out at 0, it does not go negative', () => {
+    // Negative contributions scale down what has ALREADY accumulated
+    // (d += c * d), so with no hard element to raise d first they are inert.
+    const soft = [el('copper', 60, 1, -0.7), el('iron', 40, 1, -0.4)]
+    expect(computeRockResistance(soft)).toBe(0)
+  })
+
+  it('soft elements pull an accumulated resistance back down', () => {
+    const hardOnly = [el('quantainium', 40, 1, 0.95), el('inert', 60, 1, 0)]
+    const withSoft = [el('quantainium', 40, 1, 0.95), el('copper', 60, 1, -0.7)]
+    expect(computeRockResistance(withSoft)).toBeLessThan(computeRockResistance(hardOnly))
+    expect(computeRockResistance(withSoft)).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for an empty or weightless composition', () => {
+    expect(computeRockResistance([])).toBe(0)
+    expect(computeRockResistance(undefined)).toBe(0)
+    expect(computeRockResistance([el('x', 0, 1, 0.5)])).toBe(0)
+  })
+
+  it('samples the quality roll between min_pct and max_pct', () => {
+    // A rich roll of a high-resistance element is a harder rock.
+    const rock = [
+      { element: 'quantainium', min_pct: 10, max_pct: 40, probability: 1, stats: { element_resistance: 0.95 } },
+      { element: 'iron', min_pct: 60, max_pct: 60, probability: 1, stats: { element_resistance: -0.4 } },
+    ]
+    expect(computeRockResistance(rock, 1)).toBeGreaterThan(computeRockResistance(rock, 0))
+    expect(computeRockResistance(rock, 5)).toBeCloseTo(computeRockResistance(rock, 1), 10)
+    expect(computeRockResistance(rock, -3)).toBeCloseTo(computeRockResistance(rock, 0), 10)
+  })
+})
+
+describe('computeDamageFactor', () => {
+  const ROCK = 0.24084843995748423 // the C-Type golden
+
+  it('bare loadout: damageFactor = 1 - rockResistance', () => {
+    expect(computeDamageFactor(ROCK, 0)).toBeCloseTo(0.7592, 4)
+  })
+
+  it('a positive modifier (Arbor +25%) hardens the rock', () => {
+    expect(computeDamageFactor(ROCK, 0.25)).toBeCloseTo(0.6989, 4)
+  })
+
+  it('a negative modifier (Klein -45%) softens the rock', () => {
+    expect(computeDamageFactor(ROCK, -0.3)).toBeCloseTo(0.8314, 4)
+    expect(computeDamageFactor(ROCK, -0.45)).toBeCloseTo(0.8675, 4)
+  })
+
+  it('clamps effective resistance at 0 — a soft rock never gives a damage bonus', () => {
+    expect(computeDamageFactor(-0.5, 0)).toBe(1)
+    expect(computeDamageFactor(0.2, -3)).toBe(1)
+  })
+
+  it('clamps effective resistance at 0.95 — damage never reaches zero', () => {
+    expect(computeDamageFactor(0.95, 2)).toBeCloseTo(0.05, 10)
+  })
+
+  it('defaults a missing modifier to none', () => {
+    expect(computeDamageFactor(ROCK)).toBeCloseTo(1 - ROCK, 10)
+  })
+})

--- a/frontend/src/pages/Mining/computeRockResistance.test.js
+++ b/frontend/src/pages/Mining/computeRockResistance.test.js
@@ -24,8 +24,8 @@ const C_TYPE = [
 ]
 
 describe('computeRockResistance', () => {
-  it('matches the C-Type asteroid golden (0.2408)', () => {
-    expect(computeRockResistance(C_TYPE)).toBeCloseTo(0.2408, 4)
+  it('matches the C-Type asteroid golden (0.24085)', () => {
+    expect(computeRockResistance(C_TYPE)).toBeCloseTo(0.24085, 5)
   })
 
   it('renormalises percentages — scaling every weight leaves the result unchanged', () => {
@@ -47,9 +47,9 @@ describe('computeRockResistance', () => {
   })
 
   it('a trace of a hard element contributes sub-linearly, not proportionally', () => {
-    // 2% quantainium: pow(0.02, 0.6) * 0.95 = 0.0909, not 0.019.
+    // 2% quantainium: pow(0.02, 0.6) * 0.95 = 0.09085, not 0.019.
     const trace = [el('quantainium', 2, 1, 0.95), el('iron', 98, 1, 0)]
-    expect(computeRockResistance(trace)).toBeCloseTo(0.0909, 4)
+    expect(computeRockResistance(trace)).toBeCloseTo(0.09085, 5)
   })
 
   it('an all-soft rock bottoms out at 0, it does not go negative', () => {

--- a/frontend/src/pages/Mining/miningUtils.js
+++ b/frontend/src/pages/Mining/miningUtils.js
@@ -61,11 +61,13 @@ export const MOD_LABELS = {
   mod_filter: 'Inert Filter',
 }
 
-// Whether a positive value for this modifier is good (true) or bad (false)
+// Whether a positive value for this modifier is good (true) or bad (false).
+// mod_resistance is false: it scales the ROCK's resistance (× 1 + mod), so a
+// negative value (Klein -45%) is the desirable one.
 export const MOD_POSITIVE_IS_GOOD = {
   mod_instability: false,
   mod_optimal_window_size: true,
-  mod_resistance: true,
+  mod_resistance: false,
   mod_shatter_damage: true,
   mod_cluster_factor: false,
   mod_optimal_charge_rate: true,


### PR DESCRIPTION
## What

Adds the missing **rock mass** axis to the Mining Rock Calculator, and in the process replaces the page's feasibility model with a researched, resistance-adjusted one.

- **MassSlider** (new control): slider + Enter-commit editable box, per-scope ranges (ship 0–40,000 default 8,000; FPS and ROC configs ship dormant — see scope note), clamping, single tab stop, reset-to-default.
- **Crack verdict card**: CAN CRACK / CANNOT CRACK + best-case time-to-crack + power margin, from `capacity = power_capacity_per_mass × mass`, `decay = decay_per_mass × mass`, `netRate = effectiveDPS − decay`.
- **Resistance-adjusted effective DPS** (new `computeRockResistance.js`): renormalised element composition → screen-blend with 0.6 exponent → `× (1 + Σmod_resistance)` → clamp [0, 0.95]; `effectiveDPS = totalDps × (1 − resistance)`. Validated against DataCore + the scmdb community solver; full derivation in the tools repo: `docs/superpowers/specs/2026-07-30-mining-resistance-composition-findings.md`.

## Pre-existing bugs fixed (behaviour changes)

- **Laser resistance modifiers were sign-inverted** — lasers ranked backwards (Arbor +25 shown as good, Klein −45 as bad). Now `(1 + mod)` per CIG's FloatModifierMultiplicative, colour map flipped.
- **Module damage multipliers ignored** in total DPS (Rieger 1.25×, Surge 1.5×, Focus 0.85×, ArgoGEO 0.15×).
- **CAN/CANNOT BREAK banner and PowerBar retired** — both rested on `laser_damage_full_value`, which research showed is a surface-deformation normaliser, not a resistance; they could contradict the correct verdict on screen. The crack card is now the page's single feasibility read.

## Scope note

The calculator is effectively ship-only today (its scope resolution hardcodes `'ship'` even for ROC/Multi-Tool presets), so the FPS/ground-vehicle mass configs ship dormant behind the same row-pick pattern, ready for real scope threading.

## Ship checklist

- Frontend-only: **no migrations, no API/payload changes, no `gd:` purge needed** (coefficients already served via `SELECT * FROM mining_global_params`).
- Tests: frontend 613/613 (Mining suite 72→104, incl. hand-verified goldens: C-Type resistance 0.24085; bare 2000 DPS @ 8,000 mass = CANNOT CRACK; Helix ~21m 14s; Klein ~9m 52s), root 912/1 pre-existing skip, typecheck clean.
- Staging smoke: borderline-mass verdict flip, slider/box Enter-commit, laser ranking now sensible (Klein best), banner/PowerBar gone. An in-game spot-check of a crack time is still advisable before trusting times as precise.

## Follow-up candidates (non-blocking)

- `computeEffectiveRockStats` still returns the two retired resistance keys (tested pure-module contract, nothing reads them).
- `laser_damage_full_value` remains as the rock-entity existence gate driving `hasResults`.
- No raw/effective DPS readout on the page any more — a base→effective DPS sub-line on the crack card would also surface the damage factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgyM7upSq9oegMqo8oDpSp